### PR TITLE
fix(client): expand mobile drawing canvas

### DIFF
--- a/client/e2e/polish.e2e.ts
+++ b/client/e2e/polish.e2e.ts
@@ -34,17 +34,21 @@ test('phone drawing screen prioritizes canvas before controls on mobile', async 
     await tv.getByRole('button', { name: 'Start Game' }).click();
 
     await expect(ava.locator('canvas.draw-canvas')).toBeVisible();
-    await expect(ava.locator('.draw-toolbar')).toBeVisible();
     await expect(ava.getByRole('button', { name: 'Submit Drawing' })).toBeVisible();
+    await expect(ava.locator('.tools-summary')).toContainText('Tools');
+    await expect(ava.locator('.draw-toolbar')).toBeHidden();
     await expect(bo.locator('canvas.draw-canvas')).toBeVisible();
 
     const canvasBox = await ava.locator('canvas.draw-canvas').boundingBox();
-    const toolbarBox = await ava.locator('.draw-toolbar').boundingBox();
-    if (!canvasBox || !toolbarBox) {
-      throw new Error('Drawing canvas and toolbar must have layout boxes.');
+    const drawerBox = await ava.locator('.tools-drawer').boundingBox();
+    if (!canvasBox || !drawerBox) {
+      throw new Error('Drawing canvas and tools drawer must have layout boxes.');
     }
-    expect(canvasBox.y).toBeLessThan(toolbarBox.y);
-    expect(canvasBox.width).toBeGreaterThan(300);
+    expect(canvasBox.y).toBeLessThan(drawerBox.y);
+    expect(canvasBox.width).toBeGreaterThan(320);
+
+    await ava.locator('.tools-summary').click();
+    await expect(ava.locator('.draw-toolbar')).toBeVisible();
   } finally {
     await Promise.all(contexts.map((context) => context.close()));
   }

--- a/client/src/drawing.ts
+++ b/client/src/drawing.ts
@@ -45,6 +45,7 @@ export class DrawingPad {
   readonly root: HTMLElement;
   private readonly canvas: HTMLCanvasElement;
   private readonly status: HTMLElement;
+  private readonly toolsSummary: HTMLElement;
   private readonly drawing: DrawingDoc = createEmptyDrawing();
   private color = COLORS[0];
   private size = SIZES[1];
@@ -63,6 +64,8 @@ export class DrawingPad {
     this.canvas.height = CANVAS_HEIGHT;
     this.status = document.createElement('div');
     this.status.className = 'draw-status';
+    this.toolsSummary = document.createElement('summary');
+    this.toolsSummary.className = 'tools-summary';
 
     const toolbar = document.createElement('div');
     toolbar.className = 'draw-toolbar';
@@ -126,13 +129,17 @@ export class DrawingPad {
     actionTools.appendChild(this.clearButton);
     toolbar.append(colorTools, sizeTools, actionTools);
 
+    const toolsDrawer = document.createElement('details');
+    toolsDrawer.className = 'tools-drawer';
+    toolsDrawer.append(this.toolsSummary, toolbar);
+
     this.root = document.createElement('section');
     this.root.className = 'drawing-pad';
     this.root.append(this.canvas);
     if (submitSlot) {
       this.root.appendChild(submitSlot);
     }
-    this.root.append(toolbar, this.status);
+    this.root.append(toolsDrawer, this.status);
     this.bindPointerEvents();
     this.redraw();
     this.updateStatus();
@@ -213,7 +220,8 @@ export class DrawingPad {
 
   private updateStatus(): void {
     const colorLabel = COLOR_LABELS[this.color] ?? this.color;
-    this.status.textContent = `${this.drawing.strokes.length} strokes · ${colorLabel} · ${this.size}px`;
+    this.toolsSummary.textContent = `Tools · ${colorLabel} · ${this.size}px`;
+    this.status.textContent = `${this.drawing.strokes.length} ${this.drawing.strokes.length === 1 ? 'stroke' : 'strokes'}`;
     this.undoButton.disabled = !this.hasInk();
     this.clearButton.disabled = !this.hasInk();
     this.updateToolState();

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -397,10 +397,42 @@ input:focus-visible,
   gap: 12px;
 }
 
+.tools-drawer {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.045);
+  overflow: hidden;
+}
+
+.tools-summary {
+  min-height: var(--touch-target);
+  padding: 14px 16px;
+  color: var(--muted-strong);
+  cursor: pointer;
+  font-weight: 900;
+  list-style: none;
+  touch-action: manipulation;
+}
+
+.tools-summary::-webkit-details-marker {
+  display: none;
+}
+
+.tools-summary::after {
+  content: "Open";
+  float: right;
+  color: var(--yellow);
+}
+
+.tools-drawer[open] .tools-summary::after {
+  content: "Close";
+}
+
 .draw-toolbar {
   display: grid;
   gap: 10px;
   align-items: center;
+  padding: 0 8px 8px;
 }
 
 .draw-tools {
@@ -513,7 +545,7 @@ input:focus-visible,
 }
 
 .player .draw-canvas {
-  width: min(100%, 54svh, 620px);
+  width: min(100%, 620px);
   justify-self: center;
 }
 
@@ -825,7 +857,7 @@ input:focus-visible,
   }
 
   .player .draw-canvas {
-    width: min(100%, 36svh, 620px);
+    width: min(100%, 620px);
   }
 
   .player .reconnect-hint {


### PR DESCRIPTION
## Summary
- Expand the phone drawing canvas by removing the mobile `svh` cap.
- Collapse colors, brush sizes, undo, and clear into a native tools drawer below Submit.
- Update the mobile polish E2E check to verify the drawer starts closed, opens, and keeps the larger canvas first.

## Validation
- `npm --prefix client run typecheck`
- `npm --prefix client test -- --run`
- `npm --prefix client run build`
- `npm run e2e`
- Local Playwright screenshot smoke at 390x844 confirmed the collapsed drawer keeps the canvas at 328x246 with Submit visible.

## Risk / Notes
- Client-only UI change. No protocol, server, persistence, or deployment setting changes.
