### PR TITLE
feat: mid-game joins as spectators until the next round

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ For narrow changes, match validation to blast radius:
 - Keep the Rust server authoritative. Do not reintroduce peer-to-peer room authority or client-side phase ownership.
 - Centralize phase advancement in the engine rather than duplicating progression rules in route handlers or client code.
 - Preserve reconnect and dropout behavior: disconnected players should not block progress once all connected eligible players have submitted.
-- Keep room and player limits enforced on both protocol constants and user-facing controls.
+- Keep room and player limits enforced on both protocol constants and user-facing controls. Spectators consume `MAX_PLAYERS` seats (same roster cap as active players).
 - Keep client protocol guards strict; unknown or malformed server messages should not mutate UI state.
 - Avoid complex drawing features unless they directly improve the simple party flow.
 - Prefer small, reviewable changes with tests close to the changed behavior.

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -19,6 +19,14 @@ import { bindAdvanceButton, isRevealComplete, resetReveal, scheduleReveal } from
 import { renderScoresPanel } from './scores-panel';
 import { renderSettingsPanel } from './settings-panel';
 import { playCue } from './sound';
+import {
+  activePlayers,
+  participationMode,
+  playerCountLabel,
+  playingPlayers,
+  spectatorBanner,
+  type ParticipationMode
+} from './spectator';
 import { viewKeyFor } from './store';
 import { formatDeadline, nowMs, syncServerClock } from './time';
 
@@ -268,107 +276,31 @@ function renderPlayer(): HTMLElement {
     return renderJoin();
   }
 
-  if (isSpectating()) {
-    if (snapshot.phase === 'results') {
-      return shell('Spectating', renderResults(snapshot.roundResult, false));
-    }
-    if (snapshot.phase === 'finalScores') {
-      return shell('Spectating', renderScores(snapshot.finalScores, true));
-    }
-    return shell('Spectating', renderSpectatorWatch());
-  }
+  const mode = participationMode(snapshot.players, clientId);
+  const watching = mode === 'watch';
 
-  if (snapshot.phase === 'lobby') {
-    return shell('Lobby', renderPlayerLobby());
+  switch (snapshot.phase) {
+    case 'lobby':
+      return shell(watching ? 'Spectating' : 'Lobby', renderPlayerLobby());
+    case 'drawing':
+      return shell(watching ? 'Spectating' : 'Draw', renderDrawingTurn(mode));
+    case 'guessing':
+      return shell(watching ? 'Spectating' : 'Guess', renderGuessingTurn(mode));
+    case 'voting':
+      return shell(watching ? 'Spectating' : 'Vote', renderVotingTurn(mode));
+    case 'results':
+      return shell(watching ? 'Spectating' : 'Results', renderResults(snapshot.roundResult, false));
+    case 'finalScores':
+      return shell(watching ? 'Spectating' : 'Final Scores', renderScores(snapshot.finalScores, true));
+    default: {
+      const _exhaustive: never = snapshot.phase;
+      return _exhaustive;
+    }
   }
-  if (snapshot.phase === 'drawing') {
-    return shell('Draw', renderDrawingTurn());
-  }
-  if (snapshot.phase === 'guessing') {
-    return shell('Guess', renderGuessingTurn());
-  }
-  if (snapshot.phase === 'voting') {
-    return shell('Vote', renderVotingTurn());
-  }
-  if (snapshot.phase === 'results') {
-    return shell('Results', renderResults(snapshot.roundResult, false));
-  }
-  return shell('Final Scores', renderScores(snapshot.finalScores, true));
 }
 
 function isSpectating(): boolean {
-  return Boolean(snapshot?.players.find((player) => player.id === clientId)?.spectator);
-}
-
-function renderSpectatorWatch(): HTMLElement {
-  if (!snapshot) {
-    return el('section', { class: 'panel narrow spectator-banner' });
-  }
-
-  const phase = snapshot.phase;
-  const banner = el(
-    'div',
-    { class: 'spectator-banner' },
-    el('span', { class: 'pill spectator-pill' }, 'Spectating'),
-    el('p', { class: 'muted' }, 'Watch-only for now. You join as a player on the next drawing round.')
-  );
-
-  if (phase === 'drawing') {
-    return el(
-      'section',
-      { class: 'panel play-panel player-turn-panel spectator-turn' },
-      banner,
-      el(
-        'div',
-        { class: 'turn-header' },
-        el(
-          'div',
-          { class: 'turn-copy' },
-          el('p', { class: 'eyebrow' }, `Round ${snapshot.currentRound} of ${snapshot.totalRounds}`),
-          el('div', { class: 'prompt small' }, 'Players are drawing')
-        ),
-        el('div', { class: 'deadline', id: 'deadline-text' })
-      ),
-      el('p', { class: 'action-hint' }, 'Sit tight and watch the TV.'),
-      renderProgressPanel('Drawings', snapshot.drawingSubmittedIds, 'drawing')
-    );
-  }
-
-  if (phase === 'guessing' || phase === 'voting') {
-    const canvas = document.createElement('canvas');
-    canvas.className = 'reveal-canvas phone-canvas';
-    renderDrawing(canvas, snapshot.currentDrawing);
-    const isVoting = phase === 'voting';
-    return el(
-      'section',
-      { class: 'panel play-panel player-turn-panel spectator-turn' },
-      banner,
-      el(
-        'div',
-        { class: 'turn-header compact' },
-        el(
-          'div',
-          { class: 'turn-copy' },
-          el('p', { class: 'eyebrow' }, snapshot.currentArtistName ? `By ${snapshot.currentArtistName}` : 'Reveal'),
-          el('div', { class: 'prompt small' }, isVoting ? 'Players are voting' : 'Players are guessing')
-        ),
-        el('div', { class: 'deadline', id: 'deadline-text' })
-      ),
-      canvas,
-      isVoting ? renderVotingOptions(snapshot.votingOptions, false) : null,
-      renderReactionBar(),
-      renderReconnectHint(isVoting ? 'Watch the vote on the TV.' : 'Watch the guesses roll in.')
-    );
-  }
-
-  return el(
-    'section',
-    { class: 'panel narrow spectator-banner' },
-    banner,
-    el('h2', {}, 'Watching the party'),
-    el('p', { class: 'muted' }, 'You are watching this room.'),
-    renderPlayersPanel(false)
-  );
+  return snapshot ? participationMode(snapshot.players, clientId) === 'watch' : false;
 }
 
 function renderJoin(): HTMLElement {
@@ -465,7 +397,7 @@ function renderPlayerLobby(): HTMLElement {
     return el('div', { class: 'player-stack' });
   }
 
-  const connectedPlayers = snapshot.players.filter((player) => player.connected && !player.spectator);
+  const connectedPlayers = activePlayers(snapshot.players);
   const neededPlayers = Math.max(0, snapshot.minPlayers - connectedPlayers.length);
   const self = snapshot.players.find((player) => player.id === clientId);
   const ready = neededPlayers === 0;
@@ -515,7 +447,7 @@ function renderRoomPanel(): HTMLElement {
     qrCanvas.replaceWith(el('p', { class: 'muted' }, joinUrl));
   });
 
-  const connectedPlayers = snapshot.players.filter((player) => player.connected && !player.spectator);
+  const connectedPlayers = activePlayers(snapshot.players);
   const canStart = connectedPlayers.length >= snapshot.minPlayers;
   const neededPlayers = Math.max(0, snapshot.minPlayers - connectedPlayers.length);
   return el(
@@ -558,7 +490,7 @@ function renderPlayersPanel(showScores: boolean): HTMLElement {
     { class: 'panel players-panel' },
     el('div', { class: 'panel-title' }, 'Players'),
     list,
-    snapshot ? el('p', { class: 'muted' }, playerCountLabel(snapshot)) : null
+    snapshot ? el('p', { class: 'muted' }, playerCountLabel(snapshot.players, snapshot.maxPlayers)) : null
   );
 }
 
@@ -590,14 +522,6 @@ function renderPlayerList(showScores: boolean): HTMLElement {
   return list;
 }
 
-function playerCountLabel(room: RoomSnapshot): string {
-  const connected = room.players.filter((player) => player.connected && !player.spectator).length;
-  const spectators = room.players.filter((player) => player.spectator && player.connected).length;
-  const spectatorNote = spectators > 0 ? ` · ${spectators} spectating` : '';
-  const playing = room.players.filter((player) => !player.spectator).length;
-  return `${connected} connected · ${playing}/${room.maxPlayers} playing${spectatorNote}`;
-}
-
 function renderLobbySidePanel(): HTMLElement {
   return el(
     'div',
@@ -611,11 +535,12 @@ function renderLobbySidePanel(): HTMLElement {
   );
 }
 
-function renderDrawingTurn(): HTMLElement {
+function renderDrawingTurn(mode: ParticipationMode = 'play'): HTMLElement {
   if (!snapshot) {
     return el('section', { class: 'panel' });
   }
 
+  const watching = mode === 'watch';
   const submitted = snapshot.drawingSubmittedIds.includes(clientId);
   const turnToken = snapshot.turnToken;
   const heading = el(
@@ -625,20 +550,35 @@ function renderDrawingTurn(): HTMLElement {
       'div',
       { class: 'turn-copy' },
       el('p', { class: 'eyebrow' }, `Round ${snapshot.currentRound} of ${snapshot.totalRounds}`),
-      el('div', { class: 'prompt', id: 'prompt-text' }, prompt ? `Draw: ${prompt}` : 'Waiting for prompt...')
+      el(
+        'div',
+        { class: watching ? 'prompt small' : 'prompt', id: watching ? undefined : 'prompt-text' },
+        watching ? 'Players are drawing' : prompt ? `Draw: ${prompt}` : 'Waiting for prompt...'
+      )
     ),
     el('div', { class: 'deadline', id: 'deadline-text' })
   );
 
+  if (watching) {
+    return el(
+      'section',
+      { class: 'panel play-panel player-turn-panel drawing-turn spectator-turn' },
+      spectatorBanner(),
+      heading,
+      el('p', { class: 'action-hint' }, 'Sit tight and watch the TV.'),
+      renderProgressPanel('Drawings', snapshot.drawingSubmittedIds, 'drawing')
+    );
+  }
+
   if (submitted) {
-  return el(
-    'section',
-    { class: 'panel play-panel player-turn-panel drawing-turn' },
-    heading,
-    el('p', { class: 'action-hint' }, playerActionHint('drawing', false)),
-    el('div', { class: 'success-box' }, 'Drawing submitted. Watch the TV.')
-  );
-}
+    return el(
+      'section',
+      { class: 'panel play-panel player-turn-panel drawing-turn' },
+      heading,
+      el('p', { class: 'action-hint' }, playerActionHint('drawing', false)),
+      el('div', { class: 'success-box' }, 'Drawing submitted. Watch the TV.')
+    );
+  }
 
   const submitButton = button('Submit Drawing', 'primary wide', () => {
     if (!drawingPad?.hasInk()) {
@@ -671,32 +611,51 @@ function renderDrawingTurn(): HTMLElement {
   );
 }
 
-function renderGuessingTurn(): HTMLElement {
+function renderGuessingTurn(mode: ParticipationMode = 'play'): HTMLElement {
   if (!snapshot) {
     return el('section', { class: 'panel' });
   }
-  const isArtist = snapshot.currentArtistId === clientId;
+  const watching = mode === 'watch';
+  const isArtist = !watching && snapshot.currentArtistId === clientId;
   const submitted = snapshot.guessSubmittedIds.includes(clientId);
   const turnToken = snapshot.turnToken;
   const canvas = document.createElement('canvas');
   canvas.className = 'reveal-canvas phone-canvas';
   renderDrawing(canvas, snapshot.currentDrawing);
 
-  if (isArtist) {
+  if (watching || isArtist) {
     return el(
       'section',
-      { class: 'panel play-panel player-turn-panel guessing-turn' },
+      { class: `panel play-panel player-turn-panel guessing-turn${watching ? ' spectator-turn' : ''}` },
+      watching ? spectatorBanner() : null,
       el(
         'div',
         { class: 'turn-header compact' },
-        el('div', { class: 'turn-copy' }, el('p', { class: 'eyebrow' }, 'Your drawing'), el('div', { class: 'prompt small' }, 'Players are guessing')),
+        el(
+          'div',
+          { class: 'turn-copy' },
+          el(
+            'p',
+            { class: 'eyebrow' },
+            watching
+              ? snapshot.currentArtistName
+                ? `By ${snapshot.currentArtistName}`
+                : 'Reveal'
+              : 'Your drawing'
+          ),
+          el('div', { class: 'prompt small' }, 'Players are guessing')
+        ),
         el('div', { class: 'deadline', id: 'deadline-text' })
       ),
-      el('p', { class: 'action-hint' }, playerActionHint('guessing', true)),
+      el('p', { class: 'action-hint' }, watching ? 'Watch the guesses roll in.' : playerActionHint('guessing', true)),
       canvas,
       playerReactionBar(),
-      renderReconnectHint('You are the artist for this reveal. Other players are writing fake answers.'),
-      el('div', { class: 'success-box' }, 'This is your drawing. Wait for guesses.')
+      renderReconnectHint(
+        watching
+          ? 'Watch the guesses roll in.'
+          : 'You are the artist for this reveal. Other players are writing fake answers.'
+      ),
+      watching ? null : el('div', { class: 'success-box' }, 'This is your drawing. Wait for guesses.')
     );
   }
 
@@ -737,31 +696,51 @@ function renderGuessingTurn(): HTMLElement {
   );
 }
 
-function renderVotingTurn(): HTMLElement {
+function renderVotingTurn(mode: ParticipationMode = 'play'): HTMLElement {
   if (!snapshot) {
     return el('section', { class: 'panel' });
   }
-  const isArtist = snapshot.currentArtistId === clientId;
+  const watching = mode === 'watch';
+  const isArtist = !watching && snapshot.currentArtistId === clientId;
   const submitted = snapshot.voteSubmittedIds.includes(clientId);
   const canvas = document.createElement('canvas');
   canvas.className = 'reveal-canvas phone-canvas';
   renderDrawing(canvas, snapshot.currentDrawing);
+  const eyebrow = watching
+    ? snapshot.currentArtistName
+      ? `By ${snapshot.currentArtistName}`
+      : 'Reveal'
+    : isArtist
+      ? 'Your drawing'
+      : 'Pick an answer';
+  const promptText = watching || isArtist ? 'Players are voting' : 'Find the real prompt';
   return el(
     'section',
-    { class: 'panel play-panel player-turn-panel voting-turn' },
+    { class: `panel play-panel player-turn-panel voting-turn${watching ? ' spectator-turn' : ''}` },
+    watching ? spectatorBanner() : null,
     el(
       'div',
       { class: 'turn-header compact' },
-      el('div', { class: 'turn-copy' }, el('p', { class: 'eyebrow' }, isArtist ? 'Your drawing' : 'Pick an answer'), el('div', { class: 'prompt small' }, isArtist ? 'Watch the vote' : 'Find the real prompt')),
+      el('div', { class: 'turn-copy' }, el('p', { class: 'eyebrow' }, eyebrow), el('div', { class: 'prompt small' }, promptText)),
       el('div', { class: 'deadline', id: 'deadline-text' })
     ),
-    el('p', { class: 'action-hint' }, playerActionHint('voting', isArtist)),
+    el('p', { class: 'action-hint' }, watching ? 'Watch the vote on the TV.' : playerActionHint('voting', isArtist)),
     canvas,
-    isArtist
-      ? el('div', { class: 'success-box' }, 'This is your drawing. Watch the vote.')
-      : renderVotingOptions(snapshot.votingOptions, true, submitted),
+    watching
+      ? renderVotingOptions(snapshot.votingOptions, false)
+      : isArtist
+        ? el('div', { class: 'success-box' }, 'This is your drawing. Watch the vote.')
+        : renderVotingOptions(snapshot.votingOptions, true, submitted),
     playerReactionBar(),
-    renderReconnectHint(submitted ? 'Your vote is in.' : isArtist ? 'You drew this one. Watch the votes come in.' : 'Choose the real prompt. You cannot vote for your own fake answer.')
+    renderReconnectHint(
+      watching
+        ? 'Watch the vote on the TV.'
+        : submitted
+          ? 'Your vote is in.'
+          : isArtist
+            ? 'You drew this one. Watch the votes come in.'
+            : 'Choose the real prompt. You cannot vote for your own fake answer.'
+    )
   );
 }
 
@@ -831,7 +810,7 @@ function renderVotingOptions(options: VotingOption[], interactive: boolean, subm
 type SubmissionPhase = 'drawing' | 'guessing' | 'voting';
 
 function renderProgressPanel(label: string, submittedIds: string[], phase: SubmissionPhase): HTMLElement {
-  const players = (snapshot?.players ?? []).filter((player) => !player.spectator);
+  const players = playingPlayers(snapshot?.players ?? []);
   const connectedPlayers = players.filter((player) => player.connected);
   const eligiblePlayers = connectedPlayers.filter((player) => phase === 'drawing' || player.id !== snapshot?.currentArtistId);
   const activeSubmittedIds = submittedIds.filter((playerId) => eligiblePlayers.some((player) => player.id === playerId));

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -268,6 +268,16 @@ function renderPlayer(): HTMLElement {
     return renderJoin();
   }
 
+  if (isSpectating()) {
+    if (snapshot.phase === 'results') {
+      return shell('Spectating', renderResults(snapshot.roundResult, false));
+    }
+    if (snapshot.phase === 'finalScores') {
+      return shell('Spectating', renderScores(snapshot.finalScores, true));
+    }
+    return shell('Spectating', renderSpectatorWatch());
+  }
+
   if (snapshot.phase === 'lobby') {
     return shell('Lobby', renderPlayerLobby());
   }
@@ -284,6 +294,30 @@ function renderPlayer(): HTMLElement {
     return shell('Results', renderResults(snapshot.roundResult, false));
   }
   return shell('Final Scores', renderScores(snapshot.finalScores, true));
+}
+
+function isSpectating(): boolean {
+  return Boolean(snapshot?.players.find((player) => player.id === clientId)?.spectator);
+}
+
+function renderSpectatorWatch(): HTMLElement {
+  const phase = snapshot?.phase ?? 'lobby';
+  const copy =
+    phase === 'drawing'
+      ? 'Players are drawing. You will jump in next round.'
+      : phase === 'guessing'
+        ? 'Watch the guesses roll in. You will play next round.'
+        : phase === 'voting'
+          ? 'Votes are in progress. You will play next round.'
+          : 'You are watching this room. You will play when the next round starts.';
+  return el(
+    'section',
+    { class: 'panel narrow spectator-banner' },
+    el('span', { class: 'pill spectator-pill' }, 'Spectator'),
+    el('h2', {}, 'Watching the party'),
+    el('p', { class: 'muted' }, copy),
+    renderPlayersPanel(false)
+  );
 }
 
 function renderJoin(): HTMLElement {
@@ -480,12 +514,22 @@ function renderPlayersPanel(showScores: boolean): HTMLElement {
 function renderPlayerList(showScores: boolean): HTMLElement {
   const list = el('div', { class: 'player-list' });
   for (const [index, player] of (snapshot?.players ?? []).entries()) {
+    const statusPill = player.spectator
+      ? 'spectating'
+      : showScores
+        ? `${player.score} pts`
+        : player.connected
+          ? 'online'
+          : 'offline';
     list.appendChild(
       el(
         'div',
-        { class: `player-row ${player.connected ? 'online' : 'offline'}`, style: `--row-index:${index}` },
+        {
+          class: `player-row ${player.connected ? 'online' : 'offline'}${player.spectator ? ' is-spectator' : ''}`,
+          style: `--row-index:${index}`
+        },
         el('span', { class: 'player-name' }, player.name),
-        el('span', { class: 'pill' }, showScores ? `${player.score} pts` : player.connected ? 'online' : 'offline')
+        el('span', { class: `pill${player.spectator ? ' spectator-pill' : ''}` }, statusPill)
       )
     );
   }
@@ -932,14 +976,19 @@ function shell(title: string, child: HTMLElement): HTMLElement {
   const waitingToJoin = role === 'player' && !pendingJoin && !snapshot;
   const reconnecting = !waitingToJoin && status !== 'Connected' && status !== 'Disconnected';
   const connectionText = displayStatusText();
+  const phaseText = snapshot
+    ? isSpectating()
+      ? `Spectating · ${phaseLabel(snapshot.phase)}`
+      : phaseLabel(snapshot.phase)
+    : null;
   return el(
     'main',
-    { class: `app-shell ${role} ${shellPhaseClass()}` },
+    { class: `app-shell ${role} ${shellPhaseClass()}${isSpectating() ? ' is-spectating' : ''}` },
     renderBackdrop(),
     el(
       'header',
       { class: 'topbar' },
-      el('div', {}, el('div', { class: 'brand' }, title), snapshot ? el('div', { class: 'phase' }, phaseLabel(snapshot.phase)) : null),
+      el('div', {}, el('div', { class: 'brand' }, title), phaseText ? el('div', { class: 'phase' }, phaseText) : null),
       el('div', { class: 'connection', id: 'connection-text' }, connectionText)
     ),
     reconnecting ? el('div', { class: 'connection-banner' }, status) : null,

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -169,7 +169,7 @@ function handleServerMessage(message: ServerMessage): void {
       break;
     case 'error':
       errorMessage = message.message;
-      if (['room_not_found', 'game_in_progress', 'room_full'].includes(message.code)) {
+      if (['room_not_found', 'room_full'].includes(message.code)) {
         pendingJoin = null;
         status = 'Ready to join';
         socket?.close();
@@ -301,21 +301,72 @@ function isSpectating(): boolean {
 }
 
 function renderSpectatorWatch(): HTMLElement {
-  const phase = snapshot?.phase ?? 'lobby';
-  const copy =
-    phase === 'drawing'
-      ? 'Players are drawing. You will jump in next round.'
-      : phase === 'guessing'
-        ? 'Watch the guesses roll in. You will play next round.'
-        : phase === 'voting'
-          ? 'Votes are in progress. You will play next round.'
-          : 'You are watching this room. You will play when the next round starts.';
+  if (!snapshot) {
+    return el('section', { class: 'panel narrow spectator-banner' });
+  }
+
+  const phase = snapshot.phase;
+  const banner = el(
+    'div',
+    { class: 'spectator-banner' },
+    el('span', { class: 'pill spectator-pill' }, 'Spectating'),
+    el('p', { class: 'muted' }, 'Watch-only for now. You join as a player on the next drawing round.')
+  );
+
+  if (phase === 'drawing') {
+    return el(
+      'section',
+      { class: 'panel play-panel player-turn-panel spectator-turn' },
+      banner,
+      el(
+        'div',
+        { class: 'turn-header' },
+        el(
+          'div',
+          { class: 'turn-copy' },
+          el('p', { class: 'eyebrow' }, `Round ${snapshot.currentRound} of ${snapshot.totalRounds}`),
+          el('div', { class: 'prompt small' }, 'Players are drawing')
+        ),
+        el('div', { class: 'deadline', id: 'deadline-text' })
+      ),
+      el('p', { class: 'action-hint' }, 'Sit tight and watch the TV.'),
+      renderProgressPanel('Drawings', snapshot.drawingSubmittedIds, 'drawing')
+    );
+  }
+
+  if (phase === 'guessing' || phase === 'voting') {
+    const canvas = document.createElement('canvas');
+    canvas.className = 'reveal-canvas phone-canvas';
+    renderDrawing(canvas, snapshot.currentDrawing);
+    const isVoting = phase === 'voting';
+    return el(
+      'section',
+      { class: 'panel play-panel player-turn-panel spectator-turn' },
+      banner,
+      el(
+        'div',
+        { class: 'turn-header compact' },
+        el(
+          'div',
+          { class: 'turn-copy' },
+          el('p', { class: 'eyebrow' }, snapshot.currentArtistName ? `By ${snapshot.currentArtistName}` : 'Reveal'),
+          el('div', { class: 'prompt small' }, isVoting ? 'Players are voting' : 'Players are guessing')
+        ),
+        el('div', { class: 'deadline', id: 'deadline-text' })
+      ),
+      canvas,
+      isVoting ? renderVotingOptions(snapshot.votingOptions, false) : null,
+      renderReactionBar(),
+      renderReconnectHint(isVoting ? 'Watch the vote on the TV.' : 'Watch the guesses roll in.')
+    );
+  }
+
   return el(
     'section',
     { class: 'panel narrow spectator-banner' },
-    el('span', { class: 'pill spectator-pill' }, 'Spectator'),
+    banner,
     el('h2', {}, 'Watching the party'),
-    el('p', { class: 'muted' }, copy),
+    el('p', { class: 'muted' }, 'You are watching this room.'),
     renderPlayersPanel(false)
   );
 }
@@ -404,7 +455,7 @@ function renderJoin(): HTMLElement {
       el('label', { class: 'label' }, 'Name'),
       nameInput,
       button('Join', 'primary wide', join),
-      errorMessage ? null : el('p', { class: 'muted join-note fine-print' }, 'Phones, tablets, and iPads all work as controllers.')
+      errorMessage ? null : el('p', { class: 'muted join-note fine-print' }, 'Join before start to play. Mid-game joins watch as spectators.')
     )
   );
 }
@@ -414,7 +465,7 @@ function renderPlayerLobby(): HTMLElement {
     return el('div', { class: 'player-stack' });
   }
 
-  const connectedPlayers = snapshot.players.filter((player) => player.connected);
+  const connectedPlayers = snapshot.players.filter((player) => player.connected && !player.spectator);
   const neededPlayers = Math.max(0, snapshot.minPlayers - connectedPlayers.length);
   const self = snapshot.players.find((player) => player.id === clientId);
   const ready = neededPlayers === 0;
@@ -464,7 +515,7 @@ function renderRoomPanel(): HTMLElement {
     qrCanvas.replaceWith(el('p', { class: 'muted' }, joinUrl));
   });
 
-  const connectedPlayers = snapshot.players.filter((player) => player.connected);
+  const connectedPlayers = snapshot.players.filter((player) => player.connected && !player.spectator);
   const canStart = connectedPlayers.length >= snapshot.minPlayers;
   const neededPlayers = Math.max(0, snapshot.minPlayers - connectedPlayers.length);
   return el(
@@ -540,8 +591,11 @@ function renderPlayerList(showScores: boolean): HTMLElement {
 }
 
 function playerCountLabel(room: RoomSnapshot): string {
-  const connected = room.players.filter((player) => player.connected).length;
-  return `${connected} connected · ${room.players.length}/${room.maxPlayers} joined`;
+  const connected = room.players.filter((player) => player.connected && !player.spectator).length;
+  const spectators = room.players.filter((player) => player.spectator && player.connected).length;
+  const spectatorNote = spectators > 0 ? ` · ${spectators} spectating` : '';
+  const playing = room.players.filter((player) => !player.spectator).length;
+  return `${connected} connected · ${playing}/${room.maxPlayers} playing${spectatorNote}`;
 }
 
 function renderLobbySidePanel(): HTMLElement {
@@ -777,7 +831,7 @@ function renderVotingOptions(options: VotingOption[], interactive: boolean, subm
 type SubmissionPhase = 'drawing' | 'guessing' | 'voting';
 
 function renderProgressPanel(label: string, submittedIds: string[], phase: SubmissionPhase): HTMLElement {
-  const players = snapshot?.players ?? [];
+  const players = (snapshot?.players ?? []).filter((player) => !player.spectator);
   const connectedPlayers = players.filter((player) => player.connected);
   const eligiblePlayers = connectedPlayers.filter((player) => phase === 'drawing' || player.id !== snapshot?.currentArtistId);
   const activeSubmittedIds = submittedIds.filter((playerId) => eligiblePlayers.some((player) => player.id === playerId));

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -19,14 +19,13 @@ import { bindAdvanceButton, isRevealComplete, resetReveal, scheduleReveal } from
 import { renderScoresPanel } from './scores-panel';
 import { renderSettingsPanel } from './settings-panel';
 import { playCue } from './sound';
+import { renderProgressPanel } from './progress-panel';
 import {
   activePlayers,
   participationMode,
-  playerCountLabel,
-  playingPlayers,
-  spectatorBanner,
-  type ParticipationMode
+  playerCountLabel
 } from './spectator';
+import { renderSpectatorView } from './spectator-views';
 import { viewKeyFor } from './store';
 import { formatDeadline, nowMs, syncServerClock } from './time';
 
@@ -249,18 +248,18 @@ function renderDisplay(): HTMLElement {
   } else if (snapshot.phase === 'drawing') {
     content.append(
       heroPanel('Players are drawing', `Round ${snapshot.currentRound} of ${snapshot.totalRounds}`),
-      renderProgressPanel('Drawings', snapshot.drawingSubmittedIds, 'drawing')
+      renderProgressPanel(snapshot, 'Drawings', snapshot.drawingSubmittedIds, 'drawing')
     );
   } else if (snapshot.phase === 'guessing') {
     content.append(
       renderRevealPanel('What is this?', false),
-      renderProgressPanel('Guesses', snapshot.guessSubmittedIds, 'guessing')
+      renderProgressPanel(snapshot, 'Guesses', snapshot.guessSubmittedIds, 'guessing')
     );
   } else if (snapshot.phase === 'voting') {
     content.append(
       renderRevealPanel('Vote for the real prompt', false),
       renderVotingOptions(snapshot.votingOptions, false),
-      renderProgressPanel('Votes', snapshot.voteSubmittedIds, 'voting')
+      renderProgressPanel(snapshot, 'Votes', snapshot.voteSubmittedIds, 'voting')
     );
   } else if (snapshot.phase === 'results') {
     content.append(renderResults(snapshot.roundResult, true), renderAdvancePanel());
@@ -276,24 +275,38 @@ function renderPlayer(): HTMLElement {
     return renderJoin();
   }
 
-  const mode = participationMode(snapshot.players, clientId);
-  const watching = mode === 'watch';
+  const room = snapshot;
+  if (isSpectating()) {
+    return shell(
+      'Spectating',
+      renderSpectatorView(room, {
+        lobby: renderPlayerLobby,
+        drawingProgress: () =>
+          renderProgressPanel(room, 'Drawings', room.drawingSubmittedIds, 'drawing'),
+        reactionBar: playerReactionBar,
+        reconnectHint: renderReconnectHint,
+        votingOptions: () => renderVotingOptions(room.votingOptions, false),
+        results: () => renderResults(room.roundResult, false),
+        scores: () => renderScores(room.finalScores, true)
+      })
+    );
+  }
 
-  switch (snapshot.phase) {
+  switch (room.phase) {
     case 'lobby':
-      return shell(watching ? 'Spectating' : 'Lobby', renderPlayerLobby());
+      return shell('Lobby', renderPlayerLobby());
     case 'drawing':
-      return shell(watching ? 'Spectating' : 'Draw', renderDrawingTurn(mode));
+      return shell('Draw', renderDrawingTurn());
     case 'guessing':
-      return shell(watching ? 'Spectating' : 'Guess', renderGuessingTurn(mode));
+      return shell('Guess', renderGuessingTurn());
     case 'voting':
-      return shell(watching ? 'Spectating' : 'Vote', renderVotingTurn(mode));
+      return shell('Vote', renderVotingTurn());
     case 'results':
-      return shell(watching ? 'Spectating' : 'Results', renderResults(snapshot.roundResult, false));
+      return shell('Results', renderResults(room.roundResult, false));
     case 'finalScores':
-      return shell(watching ? 'Spectating' : 'Final Scores', renderScores(snapshot.finalScores, true));
+      return shell('Final Scores', renderScores(room.finalScores, true));
     default: {
-      const _exhaustive: never = snapshot.phase;
+      const _exhaustive: never = room.phase;
       return _exhaustive;
     }
   }
@@ -535,12 +548,11 @@ function renderLobbySidePanel(): HTMLElement {
   );
 }
 
-function renderDrawingTurn(mode: ParticipationMode = 'play'): HTMLElement {
+function renderDrawingTurn(): HTMLElement {
   if (!snapshot) {
     return el('section', { class: 'panel' });
   }
 
-  const watching = mode === 'watch';
   const submitted = snapshot.drawingSubmittedIds.includes(clientId);
   const turnToken = snapshot.turnToken;
   const heading = el(
@@ -550,25 +562,10 @@ function renderDrawingTurn(mode: ParticipationMode = 'play'): HTMLElement {
       'div',
       { class: 'turn-copy' },
       el('p', { class: 'eyebrow' }, `Round ${snapshot.currentRound} of ${snapshot.totalRounds}`),
-      el(
-        'div',
-        { class: watching ? 'prompt small' : 'prompt', id: watching ? undefined : 'prompt-text' },
-        watching ? 'Players are drawing' : prompt ? `Draw: ${prompt}` : 'Waiting for prompt...'
-      )
+      el('div', { class: 'prompt', id: 'prompt-text' }, prompt ? `Draw: ${prompt}` : 'Waiting for prompt...')
     ),
     el('div', { class: 'deadline', id: 'deadline-text' })
   );
-
-  if (watching) {
-    return el(
-      'section',
-      { class: 'panel play-panel player-turn-panel drawing-turn spectator-turn' },
-      spectatorBanner(),
-      heading,
-      el('p', { class: 'action-hint' }, 'Sit tight and watch the TV.'),
-      renderProgressPanel('Drawings', snapshot.drawingSubmittedIds, 'drawing')
-    );
-  }
 
   if (submitted) {
     return el(
@@ -611,51 +608,32 @@ function renderDrawingTurn(mode: ParticipationMode = 'play'): HTMLElement {
   );
 }
 
-function renderGuessingTurn(mode: ParticipationMode = 'play'): HTMLElement {
+function renderGuessingTurn(): HTMLElement {
   if (!snapshot) {
     return el('section', { class: 'panel' });
   }
-  const watching = mode === 'watch';
-  const isArtist = !watching && snapshot.currentArtistId === clientId;
+  const isArtist = snapshot.currentArtistId === clientId;
   const submitted = snapshot.guessSubmittedIds.includes(clientId);
   const turnToken = snapshot.turnToken;
   const canvas = document.createElement('canvas');
   canvas.className = 'reveal-canvas phone-canvas';
   renderDrawing(canvas, snapshot.currentDrawing);
 
-  if (watching || isArtist) {
+  if (isArtist) {
     return el(
       'section',
-      { class: `panel play-panel player-turn-panel guessing-turn${watching ? ' spectator-turn' : ''}` },
-      watching ? spectatorBanner() : null,
+      { class: 'panel play-panel player-turn-panel guessing-turn' },
       el(
         'div',
         { class: 'turn-header compact' },
-        el(
-          'div',
-          { class: 'turn-copy' },
-          el(
-            'p',
-            { class: 'eyebrow' },
-            watching
-              ? snapshot.currentArtistName
-                ? `By ${snapshot.currentArtistName}`
-                : 'Reveal'
-              : 'Your drawing'
-          ),
-          el('div', { class: 'prompt small' }, 'Players are guessing')
-        ),
+        el('div', { class: 'turn-copy' }, el('p', { class: 'eyebrow' }, 'Your drawing'), el('div', { class: 'prompt small' }, 'Players are guessing')),
         el('div', { class: 'deadline', id: 'deadline-text' })
       ),
-      el('p', { class: 'action-hint' }, watching ? 'Watch the guesses roll in.' : playerActionHint('guessing', true)),
+      el('p', { class: 'action-hint' }, playerActionHint('guessing', true)),
       canvas,
       playerReactionBar(),
-      renderReconnectHint(
-        watching
-          ? 'Watch the guesses roll in.'
-          : 'You are the artist for this reveal. Other players are writing fake answers.'
-      ),
-      watching ? null : el('div', { class: 'success-box' }, 'This is your drawing. Wait for guesses.')
+      renderReconnectHint('You are the artist for this reveal. Other players are writing fake answers.'),
+      el('div', { class: 'success-box' }, 'This is your drawing. Wait for guesses.')
     );
   }
 
@@ -696,50 +674,41 @@ function renderGuessingTurn(mode: ParticipationMode = 'play'): HTMLElement {
   );
 }
 
-function renderVotingTurn(mode: ParticipationMode = 'play'): HTMLElement {
+function renderVotingTurn(): HTMLElement {
   if (!snapshot) {
     return el('section', { class: 'panel' });
   }
-  const watching = mode === 'watch';
-  const isArtist = !watching && snapshot.currentArtistId === clientId;
+  const isArtist = snapshot.currentArtistId === clientId;
   const submitted = snapshot.voteSubmittedIds.includes(clientId);
   const canvas = document.createElement('canvas');
   canvas.className = 'reveal-canvas phone-canvas';
   renderDrawing(canvas, snapshot.currentDrawing);
-  const eyebrow = watching
-    ? snapshot.currentArtistName
-      ? `By ${snapshot.currentArtistName}`
-      : 'Reveal'
-    : isArtist
-      ? 'Your drawing'
-      : 'Pick an answer';
-  const promptText = watching || isArtist ? 'Players are voting' : 'Find the real prompt';
   return el(
     'section',
-    { class: `panel play-panel player-turn-panel voting-turn${watching ? ' spectator-turn' : ''}` },
-    watching ? spectatorBanner() : null,
+    { class: 'panel play-panel player-turn-panel voting-turn' },
     el(
       'div',
       { class: 'turn-header compact' },
-      el('div', { class: 'turn-copy' }, el('p', { class: 'eyebrow' }, eyebrow), el('div', { class: 'prompt small' }, promptText)),
+      el(
+        'div',
+        { class: 'turn-copy' },
+        el('p', { class: 'eyebrow' }, isArtist ? 'Your drawing' : 'Pick an answer'),
+        el('div', { class: 'prompt small' }, isArtist ? 'Watch the vote' : 'Find the real prompt')
+      ),
       el('div', { class: 'deadline', id: 'deadline-text' })
     ),
-    el('p', { class: 'action-hint' }, watching ? 'Watch the vote on the TV.' : playerActionHint('voting', isArtist)),
+    el('p', { class: 'action-hint' }, playerActionHint('voting', isArtist)),
     canvas,
-    watching
-      ? renderVotingOptions(snapshot.votingOptions, false)
-      : isArtist
-        ? el('div', { class: 'success-box' }, 'This is your drawing. Watch the vote.')
-        : renderVotingOptions(snapshot.votingOptions, true, submitted),
+    isArtist
+      ? el('div', { class: 'success-box' }, 'This is your drawing. Watch the vote.')
+      : renderVotingOptions(snapshot.votingOptions, true, submitted),
     playerReactionBar(),
     renderReconnectHint(
-      watching
-        ? 'Watch the vote on the TV.'
-        : submitted
-          ? 'Your vote is in.'
-          : isArtist
-            ? 'You drew this one. Watch the votes come in.'
-            : 'Choose the real prompt. You cannot vote for your own fake answer.'
+      submitted
+        ? 'Your vote is in.'
+        : isArtist
+          ? 'You drew this one. Watch the votes come in.'
+          : 'Choose the real prompt. You cannot vote for your own fake answer.'
     )
   );
 }
@@ -805,80 +774,6 @@ function renderVotingOptions(options: VotingOption[], interactive: boolean, subm
     container.appendChild(voteButton);
   }
   return container;
-}
-
-type SubmissionPhase = 'drawing' | 'guessing' | 'voting';
-
-function renderProgressPanel(label: string, submittedIds: string[], phase: SubmissionPhase): HTMLElement {
-  const players = playingPlayers(snapshot?.players ?? []);
-  const connectedPlayers = players.filter((player) => player.connected);
-  const eligiblePlayers = connectedPlayers.filter((player) => phase === 'drawing' || player.id !== snapshot?.currentArtistId);
-  const activeSubmittedIds = submittedIds.filter((playerId) => eligiblePlayers.some((player) => player.id === playerId));
-  const progress = eligiblePlayers.length === 0 ? 100 : Math.round((activeSubmittedIds.length / eligiblePlayers.length) * 100);
-  const waitingNames = eligiblePlayers
-    .filter((player) => !submittedIds.includes(player.id))
-    .map((player) => player.name);
-  return el(
-    'section',
-    { class: 'panel progress-panel' },
-    el('div', { class: 'panel-title' }, label),
-    el(
-      'div',
-      { class: 'progress-hero' },
-      el('div', { class: 'big-count' }, `${activeSubmittedIds.length}/${eligiblePlayers.length}`),
-      el('div', { class: 'progress-ring', style: `--progress:${progress}%` }, el('span', {}, `${progress}%`))
-    ),
-    el(
-      'p',
-      { class: 'muted' },
-      waitingNames.length === 0 ? 'Everyone is in.' : `Waiting on ${waitingNames.join(', ')}.`
-    ),
-    renderSubmissionList(players, submittedIds, phase)
-  );
-}
-
-function renderSubmissionList(players: RoomSnapshot['players'], submittedIds: string[], phase: SubmissionPhase): HTMLElement {
-  const list = el('div', { class: 'player-list submission-list' });
-  for (const [index, player] of players.entries()) {
-    const artist = phase !== 'drawing' && player.id === snapshot?.currentArtistId;
-    const submitted = submittedIds.includes(player.id);
-    const state = !player.connected ? 'offline' : artist ? 'artist' : submitted ? 'submitted' : 'waiting';
-    list.appendChild(
-      el(
-        'div',
-        {
-          class: `player-row submission-row ${player.connected ? 'online' : 'offline'} is-${state}`,
-          style: `--row-index:${index}`
-        },
-        el('span', { class: 'player-name' }, player.name),
-        el('span', { class: `pill status-pill status-${state}` }, submissionStatusLabel(state, phase))
-      )
-    );
-  }
-  if (!players.length) {
-    list.appendChild(el('div', { class: 'empty-state' }, 'Waiting for players.'));
-  }
-  return list;
-}
-
-function submissionStatusLabel(state: 'offline' | 'artist' | 'submitted' | 'waiting', phase: SubmissionPhase): string {
-  if (state === 'offline') {
-    return 'offline';
-  }
-  if (state === 'artist') {
-    return 'artist';
-  }
-  if (state === 'waiting') {
-    return 'waiting';
-  }
-  switch (phase) {
-    case 'drawing':
-      return 'drawing in';
-    case 'guessing':
-      return 'guess in';
-    case 'voting':
-      return 'voted';
-  }
 }
 
 function renderResults(result: RoundResult | null | undefined, includeDrawing: boolean): HTMLElement {

--- a/client/src/progress-panel.ts
+++ b/client/src/progress-panel.ts
@@ -1,0 +1,101 @@
+import { el } from './dom';
+import type { RoomSnapshot } from './protocol';
+import { playingPlayers } from './spectator';
+
+export type SubmissionPhase = 'drawing' | 'guessing' | 'voting';
+
+export function renderProgressPanel(
+  snapshot: RoomSnapshot | null | undefined,
+  label: string,
+  submittedIds: string[],
+  phase: SubmissionPhase
+): HTMLElement {
+  const players = playingPlayers(snapshot?.players ?? []);
+  const connectedPlayers = players.filter((player) => player.connected);
+  const eligiblePlayers = connectedPlayers.filter(
+    (player) => phase === 'drawing' || player.id !== snapshot?.currentArtistId
+  );
+  const activeSubmittedIds = submittedIds.filter((playerId) =>
+    eligiblePlayers.some((player) => player.id === playerId)
+  );
+  const progress =
+    eligiblePlayers.length === 0
+      ? 100
+      : Math.round((activeSubmittedIds.length / eligiblePlayers.length) * 100);
+  const waitingNames = eligiblePlayers
+    .filter((player) => !submittedIds.includes(player.id))
+    .map((player) => player.name);
+  return el(
+    'section',
+    { class: 'panel progress-panel' },
+    el('div', { class: 'panel-title' }, label),
+    el(
+      'div',
+      { class: 'progress-hero' },
+      el('div', { class: 'big-count' }, `${activeSubmittedIds.length}/${eligiblePlayers.length}`),
+      el('div', { class: 'progress-ring', style: `--progress:${progress}%` }, el('span', {}, `${progress}%`))
+    ),
+    el(
+      'p',
+      { class: 'muted' },
+      waitingNames.length === 0 ? 'Everyone is in.' : `Waiting on ${waitingNames.join(', ')}.`
+    ),
+    renderSubmissionList(players, submittedIds, phase, snapshot?.currentArtistId)
+  );
+}
+
+function renderSubmissionList(
+  players: RoomSnapshot['players'],
+  submittedIds: string[],
+  phase: SubmissionPhase,
+  currentArtistId: string | null | undefined
+): HTMLElement {
+  const list = el('div', { class: 'player-list submission-list' });
+  for (const [index, player] of players.entries()) {
+    const artist = phase !== 'drawing' && player.id === currentArtistId;
+    const submitted = submittedIds.includes(player.id);
+    const state = !player.connected ? 'offline' : artist ? 'artist' : submitted ? 'submitted' : 'waiting';
+    list.appendChild(
+      el(
+        'div',
+        {
+          class: `player-row submission-row ${player.connected ? 'online' : 'offline'} is-${state}`,
+          style: `--row-index:${index}`
+        },
+        el('span', { class: 'player-name' }, player.name),
+        el('span', { class: `pill status-pill status-${state}` }, submissionStatusLabel(state, phase))
+      )
+    );
+  }
+  if (!players.length) {
+    list.appendChild(el('div', { class: 'empty-state' }, 'Waiting for players.'));
+  }
+  return list;
+}
+
+function submissionStatusLabel(
+  state: 'offline' | 'artist' | 'submitted' | 'waiting',
+  phase: SubmissionPhase
+): string {
+  if (state === 'offline') {
+    return 'offline';
+  }
+  if (state === 'artist') {
+    return 'artist';
+  }
+  if (state === 'waiting') {
+    return 'waiting';
+  }
+  switch (phase) {
+    case 'drawing':
+      return 'drawing in';
+    case 'guessing':
+      return 'guess in';
+    case 'voting':
+      return 'voted';
+    default: {
+      const _exhaustive: never = phase;
+      return _exhaustive;
+    }
+  }
+}

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -33,6 +33,7 @@ export interface PlayerPublic {
   name: string;
   score: number;
   connected: boolean;
+  spectator: boolean;
 }
 
 export interface RoomSettings {
@@ -258,7 +259,8 @@ function isPlayer(value: unknown): value is PlayerPublic {
     typeof value.id === 'string' &&
     typeof value.name === 'string' &&
     typeof value.score === 'number' &&
-    typeof value.connected === 'boolean'
+    typeof value.connected === 'boolean' &&
+    typeof value.spectator === 'boolean'
   );
 }
 

--- a/client/src/spectator-views.ts
+++ b/client/src/spectator-views.ts
@@ -1,0 +1,126 @@
+import { el } from './dom';
+import { renderDrawing } from './drawing';
+import type { RoomSnapshot } from './protocol';
+import { spectatorBanner } from './spectator';
+
+export type SpectatorViewDeps = {
+  lobby: () => HTMLElement;
+  drawingProgress: () => HTMLElement;
+  reactionBar: () => HTMLElement;
+  reconnectHint: (message: string) => HTMLElement;
+  votingOptions: () => HTMLElement;
+  results: () => HTMLElement;
+  scores: () => HTMLElement;
+};
+
+/** Watch-only player content for each phase. Play turn UIs stay in main.ts. */
+export function renderSpectatorView(snapshot: RoomSnapshot, deps: SpectatorViewDeps): HTMLElement {
+  switch (snapshot.phase) {
+    case 'lobby':
+      return deps.lobby();
+    case 'drawing':
+      return renderSpectatorDrawingWatch(snapshot, deps.drawingProgress());
+    case 'guessing':
+      return renderSpectatorGuessingWatch(
+        snapshot,
+        deps.reactionBar(),
+        deps.reconnectHint('Watch the guesses roll in.')
+      );
+    case 'voting':
+      return renderSpectatorVotingWatch(
+        snapshot,
+        deps.votingOptions(),
+        deps.reactionBar(),
+        deps.reconnectHint('Watch the vote on the TV.')
+      );
+    case 'results':
+      return deps.results();
+    case 'finalScores':
+      return deps.scores();
+    default: {
+      const _exhaustive: never = snapshot.phase;
+      return _exhaustive;
+    }
+  }
+}
+
+function renderSpectatorDrawingWatch(snapshot: RoomSnapshot, progressPanel: HTMLElement): HTMLElement {
+  return el(
+    'section',
+    { class: 'panel play-panel player-turn-panel drawing-turn spectator-turn' },
+    spectatorBanner(),
+    el(
+      'div',
+      { class: 'turn-header' },
+      el(
+        'div',
+        { class: 'turn-copy' },
+        el('p', { class: 'eyebrow' }, `Round ${snapshot.currentRound} of ${snapshot.totalRounds}`),
+        el('div', { class: 'prompt small' }, 'Players are drawing')
+      ),
+      el('div', { class: 'deadline', id: 'deadline-text' })
+    ),
+    el('p', { class: 'action-hint' }, 'Sit tight and watch the TV.'),
+    progressPanel
+  );
+}
+
+function renderSpectatorGuessingWatch(
+  snapshot: RoomSnapshot,
+  reactionBar: HTMLElement,
+  reconnectHint: HTMLElement
+): HTMLElement {
+  const canvas = document.createElement('canvas');
+  canvas.className = 'reveal-canvas phone-canvas';
+  renderDrawing(canvas, snapshot.currentDrawing);
+  return el(
+    'section',
+    { class: 'panel play-panel player-turn-panel guessing-turn spectator-turn' },
+    spectatorBanner(),
+    spectatorRevealHeader(snapshot, 'Players are guessing'),
+    el('p', { class: 'action-hint' }, 'Watch the guesses roll in.'),
+    canvas,
+    reactionBar,
+    reconnectHint
+  );
+}
+
+function renderSpectatorVotingWatch(
+  snapshot: RoomSnapshot,
+  optionsPanel: HTMLElement,
+  reactionBar: HTMLElement,
+  reconnectHint: HTMLElement
+): HTMLElement {
+  const canvas = document.createElement('canvas');
+  canvas.className = 'reveal-canvas phone-canvas';
+  renderDrawing(canvas, snapshot.currentDrawing);
+  return el(
+    'section',
+    { class: 'panel play-panel player-turn-panel voting-turn spectator-turn' },
+    spectatorBanner(),
+    spectatorRevealHeader(snapshot, 'Players are voting'),
+    el('p', { class: 'action-hint' }, 'Watch the vote on the TV.'),
+    canvas,
+    optionsPanel,
+    reactionBar,
+    reconnectHint
+  );
+}
+
+function spectatorRevealHeader(snapshot: RoomSnapshot, promptText: string): HTMLElement {
+  return el(
+    'div',
+    { class: 'turn-header compact' },
+    el(
+      'div',
+      { class: 'turn-copy' },
+      el(
+        'p',
+        { class: 'eyebrow' },
+        snapshot.currentArtistName ? `By ${snapshot.currentArtistName}` : 'Reveal'
+      ),
+      el('div', { class: 'prompt small' }, promptText)
+    ),
+    el('div', { class: 'deadline', id: 'deadline-text' })
+  );
+}

--- a/client/src/spectator.test.ts
+++ b/client/src/spectator.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  activePlayers,
+  connectedSpectators,
+  participationMode,
+  playerCountLabel,
+  playingPlayers
+} from './spectator';
+import type { PlayerPublic } from './protocol';
+
+function player(partial: Partial<PlayerPublic> & Pick<PlayerPublic, 'id'>): PlayerPublic {
+  return {
+    name: partial.name ?? partial.id,
+    score: partial.score ?? 0,
+    connected: partial.connected ?? true,
+    spectator: partial.spectator ?? false,
+    ...partial
+  };
+}
+
+describe('spectator helpers', () => {
+  const roster = [
+    player({ id: 'a', connected: true, spectator: false }),
+    player({ id: 'b', connected: false, spectator: false }),
+    player({ id: 'c', connected: true, spectator: true }),
+    player({ id: 'd', connected: false, spectator: true })
+  ];
+
+  it('activePlayers keeps connected non-spectators only', () => {
+    expect(activePlayers(roster).map((entry) => entry.id)).toEqual(['a']);
+  });
+
+  it('playingPlayers excludes spectators regardless of connection', () => {
+    expect(playingPlayers(roster).map((entry) => entry.id)).toEqual(['a', 'b']);
+  });
+
+  it('connectedSpectators lists live watchers', () => {
+    expect(connectedSpectators(roster).map((entry) => entry.id)).toEqual(['c']);
+  });
+
+  it('participationMode derives play vs watch', () => {
+    expect(participationMode(roster, 'a')).toBe('play');
+    expect(participationMode(roster, 'c')).toBe('watch');
+    expect(participationMode(roster, 'missing')).toBe('play');
+  });
+
+  it('playerCountLabel summarizes occupancy', () => {
+    expect(playerCountLabel(roster, 8)).toBe('1 connected · 2/8 playing · 1 spectating');
+  });
+});

--- a/client/src/spectator.ts
+++ b/client/src/spectator.ts
@@ -1,0 +1,45 @@
+import { el } from './dom';
+import type { PlayerPublic } from './protocol';
+
+export type ParticipationMode = 'play' | 'watch';
+
+/** Connected non-spectators — the roster that counts for lobby readiness and turn progress. */
+export function activePlayers(players: PlayerPublic[]): PlayerPublic[] {
+  return players.filter((player) => player.connected && !player.spectator);
+}
+
+export function playingPlayers(players: PlayerPublic[]): PlayerPublic[] {
+  return players.filter((player) => !player.spectator);
+}
+
+export function connectedSpectators(players: PlayerPublic[]): PlayerPublic[] {
+  return players.filter((player) => player.connected && player.spectator);
+}
+
+export function isSpectator(players: PlayerPublic[], clientId: string): boolean {
+  return Boolean(players.find((player) => player.id === clientId)?.spectator);
+}
+
+export function participationMode(players: PlayerPublic[], clientId: string): ParticipationMode {
+  return isSpectator(players, clientId) ? 'watch' : 'play';
+}
+
+export function spectatorBanner(): HTMLElement {
+  return el(
+    'div',
+    { class: 'spectator-banner' },
+    el('span', { class: 'pill spectator-pill' }, 'Spectating'),
+    el('p', { class: 'muted' }, 'Watch-only for now. You join as a player on the next drawing round.')
+  );
+}
+
+export function playerCountLabel(
+  players: PlayerPublic[],
+  maxPlayers: number
+): string {
+  const connected = activePlayers(players).length;
+  const spectators = connectedSpectators(players).length;
+  const spectatorNote = spectators > 0 ? ` · ${spectators} spectating` : '';
+  const playing = playingPlayers(players).length;
+  return `${connected} connected · ${playing}/${maxPlayers} playing${spectatorNote}`;
+}

--- a/client/src/store.test.ts
+++ b/client/src/store.test.ts
@@ -6,7 +6,7 @@ function snapshot(): RoomSnapshot {
   return {
     roomCode: 'ABCD',
     phase: 'lobby',
-    players: [{ id: 'p1', name: 'Ava', score: 0, connected: true }],
+    players: [{ id: 'p1', name: 'Ava', score: 0, connected: true, spectator: false }],
     minPlayers: 1,
     maxPlayers: 8,
     currentRound: 0,
@@ -44,7 +44,7 @@ describe('viewKeyFor', () => {
     const first = snapshot();
     const second = snapshot();
     second.settings.drawSeconds = 120;
-    second.players.push({ id: 'p2', name: 'Bo', score: 0, connected: true });
+    second.players.push({ id: 'p2', name: 'Bo', score: 0, connected: true, spectator: false });
 
     expect(viewKeyFor({ role: 'display', clientId: 'tv', initialRoomCode: '', snapshot: first })).not.toBe(
       viewKeyFor({ role: 'display', clientId: 'tv', initialRoomCode: '', snapshot: second })

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -24,7 +24,7 @@ export function viewKeyFor(state: ClientViewState): string {
     snapshot.settings.promptPackId
   ].join(':');
   const playersKey = snapshot.players
-    .map((player) => `${player.id}:${player.name}:${player.score}:${player.connected}`)
+    .map((player) => `${player.id}:${player.name}:${player.score}:${player.connected}:${player.spectator}`)
     .join('|');
   const scoreDeltaKey = snapshot.roundResult?.scoreDeltas.map((score) => `${score.playerId}:${score.delta}`).join('|') ?? '';
   const finalScoreKey = snapshot.finalScores.map((score) => `${score.playerId}:${score.score}`).join('|');
@@ -44,6 +44,7 @@ export function viewKeyFor(state: ClientViewState): string {
     ].join(';');
   }
 
+  const self = snapshot.players.find((player) => player.id === clientId);
   const ownDrawingSubmitted = snapshot.drawingSubmittedIds.includes(clientId);
   const ownGuessSubmitted = snapshot.guessSubmittedIds.includes(clientId);
   const ownVoteSubmitted = snapshot.voteSubmittedIds.includes(clientId);
@@ -51,6 +52,7 @@ export function viewKeyFor(state: ClientViewState): string {
     base,
     settingsKey,
     snapshot.phase === 'lobby' ? playersKey : '',
+    self?.spectator ?? false,
     ownDrawingSubmitted,
     ownGuessSubmitted,
     ownVoteSubmitted,

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1986,6 +1986,22 @@ input:focus-visible,
   color: #e8fff7;
 }
 
+.spectator-banner {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.spectator-pill,
+.pill.spectator-pill {
+  background: color-mix(in srgb, var(--ink) 12%, transparent);
+  color: var(--ink);
+}
+
+.player-row.is-spectator .player-name {
+  opacity: 0.78;
+}
+
 .error {
   background: var(--red-soft);
   color: #fff0f0;

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -17,6 +17,7 @@ pub struct Player {
     pub name: String,
     pub score: i32,
     pub connected: bool,
+    pub spectator: bool,
     #[serde(default, skip)]
     pub last_reaction_ms: u64,
 }
@@ -114,12 +115,8 @@ impl Room {
     ) -> EngineResult<()> {
         self.touch(now_ms);
         let safe_name = sanitize_name(&name);
-        if self.phase != GamePhase::Lobby && !self.players.contains_key(&player_id) {
-            return Err(EngineError::new(
-                "game_in_progress",
-                "New players can join before the game starts.",
-            ));
-        }
+        let joining_as_spectator =
+            self.phase != GamePhase::Lobby && !self.players.contains_key(&player_id);
 
         if !self.players.contains_key(&player_id) && self.players.len() >= MAX_PLAYERS {
             return Err(EngineError::new(
@@ -139,6 +136,7 @@ impl Room {
                 name: safe_name,
                 score: 0,
                 connected: true,
+                spectator: joining_as_spectator,
                 last_reaction_ms: 0,
             });
 
@@ -216,7 +214,7 @@ impl Room {
             ));
         }
         self.ensure_turn_token(turn_token)?;
-        self.ensure_connected_player(player_id, "Only connected players can submit drawings.")?;
+        self.ensure_active_player(player_id, "Only connected players can submit drawings.")?;
         validate_drawing(&drawing)?;
         if self.round.drawings.contains_key(player_id) {
             return Err(EngineError::new(
@@ -472,6 +470,7 @@ impl Room {
 
     fn start_drawing_round(&mut self, now_ms: u64) -> EngineResult<()> {
         self.prune_disconnected_players();
+        self.promote_spectators();
         if self.connected_player_count() < MIN_PLAYERS {
             let player_word = if MIN_PLAYERS == 1 {
                 "player"
@@ -487,7 +486,9 @@ impl Room {
         if self.current_round == 0 || self.phase == GamePhase::FinalScores {
             self.current_round = 1;
             for player in self.players.values_mut() {
-                player.score = 0;
+                if !player.spectator {
+                    player.score = 0;
+                }
             }
         } else {
             self.current_round = self.current_round.saturating_add(1);
@@ -498,7 +499,12 @@ impl Room {
         self.deadline_ms = Some(deadline_after(now_ms, self.settings.draw_seconds));
         self.round = RoundState::default();
 
-        let mut player_ids: Vec<String> = self.players.keys().cloned().collect();
+        let mut player_ids: Vec<String> = self
+            .players
+            .values()
+            .filter(|player| !player.spectator)
+            .map(|player| player.id.clone())
+            .collect();
         let mut rng = rand::thread_rng();
         player_ids.shuffle(&mut rng);
         self.round.order = player_ids.clone();
@@ -731,6 +737,7 @@ impl Room {
         self.current_round = self.current_round.saturating_sub(1);
         self.turn_token = self.turn_token.saturating_add(1);
         self.round = RoundState::default();
+        self.promote_spectators();
     }
 
     fn advance_after_results(&mut self, now_ms: u64) -> EngineResult<bool> {
@@ -768,12 +775,34 @@ impl Room {
             .any(|candidate| self.round.drawings.contains_key(candidate))
     }
 
+    fn promote_spectators(&mut self) {
+        for player in self.players.values_mut() {
+            player.spectator = false;
+        }
+    }
+
     fn ensure_active_non_artist(&self, player_id: &str) -> EngineResult<()> {
-        self.ensure_connected_player(player_id, "Only connected players can submit.")?;
+        self.ensure_active_player(player_id, "Only connected players can submit.")?;
         if self.round.current_artist_id.as_deref() == Some(player_id) {
             return Err(EngineError::new(
                 "artist_action",
                 "The artist skips this step.",
+            ));
+        }
+        Ok(())
+    }
+
+    fn ensure_active_player(
+        &self,
+        player_id: &str,
+        disconnected_message: &str,
+    ) -> EngineResult<()> {
+        self.ensure_connected_player(player_id, disconnected_message)?;
+        let player = self.players.get(player_id).expect("checked above");
+        if player.spectator {
+            return Err(EngineError::new(
+                "spectator",
+                "Spectators can watch but cannot submit.",
             ));
         }
         Ok(())
@@ -811,6 +840,7 @@ impl Room {
             .values()
             .filter(|player| {
                 player.connected
+                    && !player.spectator
                     && self.round.current_artist_id.as_deref() != Some(player.id.as_str())
             })
             .count()
@@ -820,7 +850,7 @@ impl Room {
         let connected_players: Vec<&Player> = self
             .players
             .values()
-            .filter(|player| player.connected)
+            .filter(|player| player.connected && !player.spectator)
             .collect();
         !connected_players.is_empty()
             && connected_players
@@ -843,6 +873,7 @@ impl Room {
             .values()
             .filter(|player| {
                 player.connected
+                    && !player.spectator
                     && self.round.current_artist_id.as_deref() != Some(player.id.as_str())
             })
             .all(|player| submissions.contains_key(&player.id))
@@ -851,7 +882,7 @@ impl Room {
     fn connected_player_count(&self) -> usize {
         self.players
             .values()
-            .filter(|player| player.connected)
+            .filter(|player| player.connected && !player.spectator)
             .count()
     }
 
@@ -867,6 +898,7 @@ impl Room {
                 name: player.name.clone(),
                 score: player.score,
                 connected: player.connected,
+                spectator: player.spectator,
             })
             .collect()
     }
@@ -875,6 +907,7 @@ impl Room {
         let mut scores: Vec<ScoreEntry> = self
             .players
             .values()
+            .filter(|player| !player.spectator)
             .map(|player| ScoreEntry {
                 player_id: player.id.clone(),
                 name: player.name.clone(),

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -118,6 +118,7 @@ impl Room {
         let joining_as_spectator =
             self.phase != GamePhase::Lobby && !self.players.contains_key(&player_id);
 
+        // Spectators consume MAX_PLAYERS seats (same roster cap as active players).
         if !self.players.contains_key(&player_id) && self.players.len() >= MAX_PLAYERS {
             return Err(EngineError::new(
                 "room_full",
@@ -469,9 +470,18 @@ impl Room {
     }
 
     fn start_drawing_round(&mut self, now_ms: u64) -> EngineResult<()> {
-        self.prune_disconnected_players();
-        self.promote_spectators();
-        if self.connected_player_count() < MIN_PLAYERS {
+        // Validate the post-promote roster before committing prune/promote/phase mutation.
+        let next_players: BTreeMap<String, Player> = self
+            .players
+            .values()
+            .filter(|player| player.connected)
+            .map(|player| {
+                let mut next = player.clone();
+                next.spectator = false;
+                (next.id.clone(), next)
+            })
+            .collect();
+        if next_players.len() < MIN_PLAYERS {
             let player_word = if MIN_PLAYERS == 1 {
                 "player"
             } else {
@@ -483,12 +493,12 @@ impl Room {
             ));
         }
 
+        self.players = next_players;
+
         if self.current_round == 0 || self.phase == GamePhase::FinalScores {
             self.current_round = 1;
             for player in self.players.values_mut() {
-                if !player.spectator {
-                    player.score = 0;
-                }
+                player.score = 0;
             }
         } else {
             self.current_round = self.current_round.saturating_add(1);
@@ -499,12 +509,7 @@ impl Room {
         self.deadline_ms = Some(deadline_after(now_ms, self.settings.draw_seconds));
         self.round = RoundState::default();
 
-        let mut player_ids: Vec<String> = self
-            .players
-            .values()
-            .filter(|player| !player.spectator)
-            .map(|player| player.id.clone())
-            .collect();
+        let mut player_ids: Vec<String> = self.players.keys().cloned().collect();
         let mut rng = rand::thread_rng();
         player_ids.shuffle(&mut rng);
         self.round.order = player_ids.clone();
@@ -655,9 +660,9 @@ impl Room {
 
         let eligible_voter_ids: Vec<String> = self
             .players
-            .keys()
-            .filter(|player_id| player_id.as_str() != artist_id.as_str())
-            .cloned()
+            .values()
+            .filter(|player| !player.spectator && player.id != artist_id)
+            .map(|player| player.id.clone())
             .collect();
         let nobody_found_it = correct_voter_names.is_empty() && !eligible_voter_ids.is_empty();
         let perfect_truth = !eligible_voter_ids.is_empty()
@@ -836,24 +841,15 @@ impl Room {
     }
 
     fn eligible_voter_count(&self) -> usize {
-        self.players
-            .values()
-            .filter(|player| {
-                player.connected
-                    && !player.spectator
-                    && self.round.current_artist_id.as_deref() != Some(player.id.as_str())
-            })
+        self.active_players()
+            .filter(|player| self.round.current_artist_id.as_deref() != Some(player.id.as_str()))
             .count()
     }
 
     fn connected_drawers_done(&self) -> bool {
-        let connected_players: Vec<&Player> = self
-            .players
-            .values()
-            .filter(|player| player.connected && !player.spectator)
-            .collect();
-        !connected_players.is_empty()
-            && connected_players
+        let drawers: Vec<&Player> = self.active_players().collect();
+        !drawers.is_empty()
+            && drawers
                 .iter()
                 .all(|player| self.round.drawings.contains_key(&player.id))
     }
@@ -869,25 +865,9 @@ impl Room {
     }
 
     fn connected_submissions_done(&self, submissions: &BTreeMap<String, String>) -> bool {
-        self.players
-            .values()
-            .filter(|player| {
-                player.connected
-                    && !player.spectator
-                    && self.round.current_artist_id.as_deref() != Some(player.id.as_str())
-            })
+        self.active_players()
+            .filter(|player| self.round.current_artist_id.as_deref() != Some(player.id.as_str()))
             .all(|player| submissions.contains_key(&player.id))
-    }
-
-    fn connected_player_count(&self) -> usize {
-        self.players
-            .values()
-            .filter(|player| player.connected && !player.spectator)
-            .count()
-    }
-
-    fn prune_disconnected_players(&mut self) {
-        self.players.retain(|_, player| player.connected);
     }
 
     fn public_players(&self) -> Vec<PlayerPublic> {
@@ -917,6 +897,14 @@ impl Room {
         scores.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.name.cmp(&b.name)));
         scores
     }
+
+    fn active_players(&self) -> impl Iterator<Item = &Player> {
+        self.players.values().filter(|player| is_active(player))
+    }
+}
+
+fn is_active(player: &Player) -> bool {
+    player.connected && !player.spectator
 }
 
 pub fn generate_room_code(existing: &BTreeSet<String>) -> String {
@@ -1103,6 +1091,5 @@ fn normalize_text(text: &str) -> String {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 #[path = "engine/tests.rs"]
 mod tests;

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -1103,5 +1103,6 @@ fn normalize_text(text: &str) -> String {
 }
 
 #[cfg(test)]
+<<<<<<< HEAD
 #[path = "engine/tests.rs"]
 mod tests;

--- a/server/src/engine/tests.rs
+++ b/server/src/engine/tests.rs
@@ -755,7 +755,9 @@ fn spectator_cannot_submit() {
         .map(|option| option.id.clone())
         .unwrap();
     assert_eq!(
-        room.submit_vote("spec", token, truth, 230).unwrap_err().code,
+        room.submit_vote("spec", token, truth, 230)
+            .unwrap_err()
+            .code,
         "spectator"
     );
 }
@@ -786,8 +788,7 @@ fn connected_progress_ignores_spectators() {
         .unwrap();
     room.submit_vote(&voters[0], token, truth.clone(), 400)
         .unwrap();
-    room.submit_vote(&voters[1], token, truth, 401)
-        .unwrap();
+    room.submit_vote(&voters[1], token, truth, 401).unwrap();
     assert_eq!(room.phase, GamePhase::Results);
     assert!(!room
         .snapshot(500)
@@ -852,4 +853,27 @@ fn late_join_during_drawing_is_spectator_until_next_round() {
     assert!(!room.players.get("p4").unwrap().spectator);
     assert!(room.round.prompts.contains_key("p4"));
     assert!(room.round.order.contains(&"p4".to_string()));
+}
+
+#[test]
+fn start_drawing_round_failure_does_not_promote_or_prune() {
+    let mut room = room_with_players();
+    room.handle_start_or_advance(100).unwrap();
+    room.upsert_player("spec".to_string(), "Spec".to_string(), 150)
+        .unwrap();
+    assert!(room.players.get("spec").unwrap().spectator);
+    assert_eq!(room.players.len(), 4);
+
+    for player_id in ["p1", "p2", "p3", "spec"] {
+        room.mark_disconnected(player_id, 200);
+    }
+    room.phase = GamePhase::FinalScores;
+    room.current_round = 1;
+
+    let err = room.handle_start_or_advance(300).unwrap_err();
+    assert_eq!(err.code, "not_enough_players");
+    assert_eq!(room.phase, GamePhase::FinalScores);
+    assert_eq!(room.players.len(), 4);
+    assert!(room.players.get("spec").unwrap().spectator);
+    assert!(!room.players.get("p1").unwrap().connected);
 }

--- a/server/src/engine/tests.rs
+++ b/server/src/engine/tests.rs
@@ -50,7 +50,12 @@ fn custom_settings() -> RoomSettings {
 
 fn submit_all_drawings(room: &mut Room, now_ms: u64) {
     let token = room.turn_token;
-    let player_ids: Vec<String> = room.players.keys().cloned().collect();
+    let player_ids: Vec<String> = room
+        .players
+        .values()
+        .filter(|player| !player.spectator)
+        .map(|player| player.id.clone())
+        .collect();
     for player_id in player_ids {
         room.submit_drawing(&player_id, token, drawing(), now_ms)
             .unwrap();
@@ -60,9 +65,9 @@ fn submit_all_drawings(room: &mut Room, now_ms: u64) {
 fn non_artist_ids(room: &Room) -> Vec<String> {
     let artist = room.round.current_artist_id.as_deref();
     room.players
-        .keys()
-        .filter(|player_id| artist != Some(player_id.as_str()))
-        .cloned()
+        .values()
+        .filter(|player| !player.spectator && artist != Some(player.id.as_str()))
+        .map(|player| player.id.clone())
         .collect()
 }
 
@@ -683,4 +688,168 @@ fn room_expires_only_after_everyone_disconnects_and_ttl_passes() {
 
     assert!(!room.is_expired(13 + ROOM_TTL_MS));
     assert!(room.is_expired(14 + ROOM_TTL_MS));
+}
+
+#[test]
+fn late_join_as_spectator_allowed() {
+    let mut room = room_with_players();
+    room.handle_start_or_advance(100).unwrap();
+    room.upsert_player("spec".to_string(), "Spectator".to_string(), 150)
+        .unwrap();
+    let spectator = room.players.get("spec").unwrap();
+    assert!(spectator.spectator);
+    assert!(spectator.connected);
+    assert!(!room.round.prompts.contains_key("spec"));
+    assert!(room
+        .snapshot(160)
+        .players
+        .iter()
+        .any(|player| player.id == "spec" && player.spectator));
+}
+
+#[test]
+fn lobby_join_creates_normal_player() {
+    let mut room = Room::new(
+        "ABCD".to_string(),
+        "display".to_string(),
+        "host-token".to_string(),
+        0,
+    );
+    room.upsert_player("p1".to_string(), "Ada".to_string(), 1)
+        .unwrap();
+    assert!(!room.players.get("p1").unwrap().spectator);
+}
+
+#[test]
+fn spectator_cannot_submit() {
+    let mut room = room_with_players();
+    room.handle_start_or_advance(100).unwrap();
+    room.upsert_player("spec".to_string(), "Spectator".to_string(), 150)
+        .unwrap();
+    let token = room.turn_token;
+    assert_eq!(
+        room.submit_drawing("spec", token, drawing(), 160)
+            .unwrap_err()
+            .code,
+        "spectator"
+    );
+    submit_all_drawings(&mut room, 200);
+    let token = room.turn_token;
+    assert_eq!(
+        room.submit_guess("spec", token, "nope".to_string(), 210)
+            .unwrap_err()
+            .code,
+        "spectator"
+    );
+    let voters = non_artist_ids(&room);
+    room.submit_guess(&voters[0], token, "fake one".to_string(), 220)
+        .unwrap();
+    room.submit_guess(&voters[1], token, "fake two".to_string(), 221)
+        .unwrap();
+    let token = room.turn_token;
+    let truth = room
+        .round
+        .voting_options
+        .iter()
+        .find(|option| option.is_correct)
+        .map(|option| option.id.clone())
+        .unwrap();
+    assert_eq!(
+        room.submit_vote("spec", token, truth, 230).unwrap_err().code,
+        "spectator"
+    );
+}
+
+#[test]
+fn connected_progress_ignores_spectators() {
+    let mut room = room_with_players();
+    room.handle_start_or_advance(100).unwrap();
+    room.upsert_player("spec".to_string(), "Spectator".to_string(), 150)
+        .unwrap();
+    submit_all_drawings(&mut room, 200);
+    assert_eq!(room.phase, GamePhase::Guessing);
+    let voters = non_artist_ids(&room);
+    assert_eq!(voters.len(), 2);
+    let token = room.turn_token;
+    room.submit_guess(&voters[0], token, "fake one".to_string(), 300)
+        .unwrap();
+    room.submit_guess(&voters[1], token, "fake two".to_string(), 301)
+        .unwrap();
+    assert_eq!(room.phase, GamePhase::Voting);
+    let token = room.turn_token;
+    let truth = room
+        .round
+        .voting_options
+        .iter()
+        .find(|option| option.is_correct)
+        .map(|option| option.id.clone())
+        .unwrap();
+    room.submit_vote(&voters[0], token, truth.clone(), 400)
+        .unwrap();
+    room.submit_vote(&voters[1], token, truth, 401)
+        .unwrap();
+    assert_eq!(room.phase, GamePhase::Results);
+    assert!(!room
+        .snapshot(500)
+        .final_scores
+        .iter()
+        .any(|entry| entry.player_id == "spec"));
+}
+
+#[test]
+fn late_join_during_drawing_is_spectator_until_next_round() {
+    let mut room = room_with_players();
+    room.settings.rounds = 2;
+    room.handle_start_or_advance(100).unwrap();
+    assert_eq!(room.phase, GamePhase::Drawing);
+
+    room.upsert_player("p4".to_string(), "Spect".to_string(), 200)
+        .unwrap();
+    assert!(room.players.get("p4").unwrap().spectator);
+    assert!(!room.round.prompts.contains_key("p4"));
+    assert!(!room.round.order.contains(&"p4".to_string()));
+
+    let drawing_token = room.turn_token;
+    for player_id in ["p1", "p2", "p3"] {
+        room.submit_drawing(player_id, drawing_token, drawing(), 300)
+            .unwrap();
+    }
+    assert_eq!(room.phase, GamePhase::Guessing);
+    assert!(room
+        .submit_guess("p4", room.turn_token, "nope".to_string(), 400)
+        .is_err());
+
+    for _ in 0..3 {
+        let artist = room.round.current_artist_id.clone().unwrap();
+        let voters: Vec<String> = room
+            .players
+            .values()
+            .filter(|player| !player.spectator && player.id != artist)
+            .map(|player| player.id.clone())
+            .collect();
+        let guess_token = room.turn_token;
+        for voter in &voters {
+            room.submit_guess(voter, guess_token, format!("fake-{voter}"), 500)
+                .unwrap();
+        }
+        let vote_token = room.turn_token;
+        let correct = room
+            .round
+            .voting_options
+            .iter()
+            .find(|option| option.is_correct)
+            .unwrap()
+            .id
+            .clone();
+        for voter in &voters {
+            room.submit_vote(voter, vote_token, correct.clone(), 600)
+                .unwrap();
+        }
+        room.handle_start_or_advance(700).unwrap();
+    }
+
+    assert_eq!(room.phase, GamePhase::Drawing);
+    assert!(!room.players.get("p4").unwrap().spectator);
+    assert!(room.round.prompts.contains_key("p4"));
+    assert!(room.round.order.contains(&"p4".to_string()));
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1201,9 +1201,9 @@ mod tests {
             .and_then(|snapshot| snapshot.get("players"))
             .and_then(Value::as_array)
             .and_then(|players| {
-                players.iter().find(|player| {
-                    player.get("id").and_then(Value::as_str) == Some("p3")
-                })
+                players
+                    .iter()
+                    .find(|player| player.get("id").and_then(Value::as_str) == Some("p3"))
             })
             .and_then(|player| player.get("spectator"))
             .and_then(Value::as_bool);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1171,7 +1171,7 @@ mod tests {
         let (room_code, _, _) = create_test_room(&mut display).await;
 
         let mut p1 = join_player(&url, &room_code, "p1", "Ada").await;
-        let _p2 = join_player(&url, &room_code, "p2", "Grace").await;
+        let mut p2 = join_player(&url, &room_code, "p2", "Grace").await;
 
         display
             .send(text_message(json!({ "type": "startGame" })))
@@ -1216,9 +1216,22 @@ mod tests {
         })))
         .await
         .unwrap();
+        p2.send(text_message(json!({
+            "type": "submitDrawing",
+            "turnToken": turn_token,
+            "drawing": drawing_value()
+        })))
+        .await
+        .unwrap();
 
-        let update = read_until_type(&mut late, "roomSnapshot").await;
-        assert!(update.get("snapshot").is_some());
+        let update = read_until_type(&mut late, "phaseChanged").await;
+        assert_eq!(
+            update
+                .get("snapshot")
+                .and_then(|snapshot| snapshot.get("phase"))
+                .and_then(Value::as_str),
+            Some("guessing")
+        );
     }
 
     #[tokio::test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1163,7 +1163,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn websocket_rejected_late_join_does_not_subscribe_to_room() {
+    async fn websocket_late_join_becomes_spectator_and_receives_room_updates() {
         let url = spawn_ws_server().await;
         let (mut display, _) = connect_async(format!("{url}?role=display&clientId=display"))
             .await
@@ -1195,11 +1195,19 @@ mod tests {
         })))
         .await
         .unwrap();
-        let error = read_until_type(&mut late, "error").await;
-        assert_eq!(
-            error.get("code").and_then(Value::as_str),
-            Some("game_in_progress")
-        );
+        let joined = read_until_type(&mut late, "roomSnapshot").await;
+        let spectator = joined
+            .get("snapshot")
+            .and_then(|snapshot| snapshot.get("players"))
+            .and_then(Value::as_array)
+            .and_then(|players| {
+                players.iter().find(|player| {
+                    player.get("id").and_then(Value::as_str) == Some("p3")
+                })
+            })
+            .and_then(|player| player.get("spectator"))
+            .and_then(Value::as_bool);
+        assert_eq!(spectator, Some(true));
 
         p1.send(text_message(json!({
             "type": "submitDrawing",
@@ -1209,7 +1217,8 @@ mod tests {
         .await
         .unwrap();
 
-        expect_no_message(&mut late).await;
+        let update = read_until_type(&mut late, "roomSnapshot").await;
+        assert!(update.get("snapshot").is_some());
     }
 
     #[tokio::test]

--- a/server/src/prompts.rs
+++ b/server/src/prompts.rs
@@ -269,10 +269,7 @@ mod tests {
     const MIN_PROMPTS_PER_PACK: usize = 100;
 
     fn assert_pack_quality(id: &str, prompts: &[&str]) {
-        assert!(
-            !prompts.is_empty(),
-            "prompt pack {id} must be non-empty"
-        );
+        assert!(!prompts.is_empty(), "prompt pack {id} must be non-empty");
         assert!(
             prompts.len() >= MIN_PROMPTS_PER_PACK,
             "prompt pack {id} has {} prompts; expected at least {MIN_PROMPTS_PER_PACK}",

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 pub const CANVAS_WIDTH: u16 = 1024;
 pub const CANVAS_HEIGHT: u16 = 768;
-pub const MAX_PLAYERS: usize = 8;
+pub const MAX_PLAYERS: usize = 8; // includes spectators — late-join watchers still consume a seat
 pub const MIN_PLAYERS: usize = 1;
 pub const DEFAULT_TOTAL_ROUNDS: u8 = 5;
 pub const TOTAL_ROUNDS: u8 = DEFAULT_TOTAL_ROUNDS;

--- a/server/src/protocol.rs
+++ b/server/src/protocol.rs
@@ -104,6 +104,7 @@ pub struct PlayerPublic {
     pub name: String,
     pub score: i32,
     pub connected: bool,
+    pub spectator: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- Allow late joiners during an in-progress game as spectators (watch-only)
- Promote spectators into active play when the next drawing round starts
- Phone UI shows spectating state; server rejects spectator submissions

## Test plan
- [x] `cargo test --manifest-path server/Cargo.toml`
- [x] `npm --prefix client run typecheck`
- [x] `npm --prefix client test -- --run`
- [ ] Manual: start a 3-player game, late-join a 4th phone, confirm watch-only then play next round
- [ ] Note: thermo review still wants membership helpers + UI decomp before merge-ready