### PR TITLE
docs: AI-optimized progressive documentation and repo organization

### DIFF
--- a/.cursor/rules/client-design.mdc
+++ b/.cursor/rules/client-design.mdc
@@ -1,0 +1,13 @@
+---
+description: Glass design system constraints
+globs: client/src/design/**,docs/design.md
+alwaysApply: false
+---
+
+Follow `docs/design.md`. Product UI is dark-first apple-glass; that overrides generic “avoid dark mode” style biases for this repo.
+
+- Keep CSS under `client/src/design/` (tokens, base, components, drawing, layout, motion).
+- Use existing button classes: `btn` / `btn--primary|secondary|ghost` / `btn--wide`.
+- Accent is for interactive actions only — no purple, neon arcade, or cream/terracotta brand fills.
+- Animate `transform` and `opacity` only; honor `prefers-reduced-motion`.
+- When tokens or component rules change, update both CSS and `docs/design.md`.

--- a/.cursor/rules/client-protocol.mdc
+++ b/.cursor/rules/client-protocol.mdc
@@ -1,0 +1,13 @@
+---
+description: Dual-update protocol contract
+globs: client/src/protocol.ts,server/src/protocol.rs
+alwaysApply: false
+---
+
+Protocol types and gameplay constants are shared across Rust and TypeScript.
+
+- Edit `server/src/protocol.rs` and `client/src/protocol.ts` together.
+- Keep JSON `camelCase` and tagged `type` discriminators consistent.
+- Client guards must reject unknown or malformed server messages without mutating UI state.
+- Update `docs/protocol.md` when constants, messages, or limits change.
+- Validate with `cargo test --manifest-path server/Cargo.toml`, `npm --prefix client test -- --run`, and `npm --prefix client run typecheck`.

--- a/.cursor/rules/server-authority.mdc
+++ b/.cursor/rules/server-authority.mdc
@@ -1,0 +1,13 @@
+---
+description: Server authority and engine validation
+globs: server/**
+alwaysApply: false
+---
+
+The Rust server is authoritative for rooms, phase transitions, deadlines, scoring, reconnect/dropout, and cleanup.
+
+- Centralize phase advancement in `server/src/engine.rs`, not route handlers or the client.
+- Disconnected players must not block progress once connected eligible players have submitted.
+- Spectators consume `MAX_PLAYERS` seats; mid-game joiners stay spectators until the next drawing round.
+- After engine or scoring changes, run `cargo test --manifest-path server/Cargo.toml` and keep `docs/architecture.md` aligned.
+- Protocol constants and message types live in `server/src/protocol.rs` — mirror changes in `client/src/protocol.ts` and `docs/protocol.md`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What changed and why -->
+
+## Test plan
+
+- [ ] Matched validation to blast radius (see `AGENTS.md` / `docs/contributing.md`)
+- [ ] Engine / scoring: `cargo test --manifest-path server/Cargo.toml` (if touched)
+- [ ] WebSocket / reconnect / health / static: Rust tests including `main.rs` (if touched)
+- [ ] Client logic / protocol: `npm --prefix client test -- --run` + typecheck (if touched)
+- [ ] UI / layout / touch: relevant Playwright e2e, including mobile phone contexts (if touched)
+- [ ] Protocol changes updated both `server/src/protocol.rs` and `client/src/protocol.ts` (+ `docs/protocol.md`)
+- [ ] Docs updated when architecture, design, or deploy behavior changed
+
+## Notes
+
+<!-- Screenshots, deploy smoke, or follow-ups -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,29 +69,19 @@ Scoring values and reconnect rules: [docs/architecture.md](docs/architecture.md)
 | Design tokens or glass rules | `client/src/design/**`, `docs/design.md` |
 | Client phase ownership or routes | `docs/client-ui.md` (do not move phase authority to the client) |
 | Env / deploy / PWA cache | `docs/deployment.md`, README deploy section if the quick start changes |
-| Validation commands | `docs/contributing.md`, `AGENTS.md`, CI |
+| Validation commands | `docs/contributing.md` only (README/AGENTS link there) |
 
 ## Validation
 
-Use the repo scripts and direct toolchain commands already documented in `README.md` and CI:
+Canonical command list and blast-radius matrix: [docs/contributing.md](docs/contributing.md#validation).
 
-```bash
-cargo fmt --check --manifest-path server/Cargo.toml
-cargo clippy --manifest-path server/Cargo.toml --all-targets -- -D warnings
-cargo test --manifest-path server/Cargo.toml
-npm --prefix client run typecheck
-npm --prefix client test -- --run
-npm --prefix client run build
-npm run e2e
-```
+Narrow change tips (see contributing for the full matrix):
 
-For narrow changes, match validation to blast radius:
-
-- Engine or scoring changes: `cargo test --manifest-path server/Cargo.toml`, plus targeted tests in `server/src/engine/tests.rs`.
-- WebSocket, reconnect, health, or static-serving changes: `cargo test --manifest-path server/Cargo.toml`, plus relevant tests in `server/src/main.rs`.
-- Client logic or protocol changes: `npm --prefix client test -- --run` and `npm --prefix client run typecheck`.
-- UI/layout/touch changes: relevant Playwright e2e coverage, including mobile-sized phone contexts.
-- Release/deployment verification: check `/api/health` for the expected deployed commit, then run `E2E_BASE_URL=<deployment-url> npm run e2e` when practical.
+- Engine / scoring: `cargo test --manifest-path server/Cargo.toml` (+ `server/src/engine/tests.rs`)
+- WebSocket / reconnect / health / static: `cargo test` including `main.rs` tests
+- Client logic / protocol: `npm --prefix client test -- --run` + typecheck
+- UI / layout / touch: relevant Playwright e2e (include mobile phone contexts)
+- Release verification: `/api/health` commit check, then `E2E_BASE_URL=<url> npm run e2e` when practical
 
 ## Development Guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Draw Party Agent Context
 
+Canonical guidance for AI agents working in this repository. Deep dives live under [`docs/`](docs/README.md) — open only what the task needs.
+
 ## Project Overview
 
 Draw Party is an open-source Drawful-style party game for a TV/display browser and phone controllers. The display creates a room and shows a QR/code. Players join from phones, draw assigned prompts, submit fake guesses for other drawings, vote for the real prompt, and score points for correct votes and convincing fake answers.
@@ -12,6 +14,17 @@ Draw Party is an open-source Drawful-style party game for a TV/display browser a
 - Prefer reliability, clear recovery, and readable code over broad feature expansion.
 - Keep v1 ephemeral: no accounts, no database, no persistent room history.
 
+## Docs Index
+
+| Doc | Use when |
+|-----|----------|
+| [docs/architecture.md](docs/architecture.md) | Phases, authority, reconnect, spectators, scoring |
+| [docs/protocol.md](docs/protocol.md) | Constants, messages, dual Rust/TS updates |
+| [docs/client-ui.md](docs/client-ui.md) | React tree, phase screens, client non-negotiables |
+| [docs/design.md](docs/design.md) | Glass tokens, type, motion, components |
+| [docs/deployment.md](docs/deployment.md) | Env vars, Docker, Railway, PWA/cache |
+| [docs/contributing.md](docs/contributing.md) | Prerequisites, scripts, PR validation |
+
 ## Current Architecture
 
 - `server/` is the Rust authoritative game server. It owns rooms, host tokens, WebSocket connections, phase transitions, deadlines, prompt assignment, scoring, reconnect/dropout handling, room cleanup, static client serving, and `/api/health` deploy metadata.
@@ -21,14 +34,19 @@ Draw Party is an open-source Drawful-style party game for a TV/display browser a
 
 ## Important Source Areas
 
-- `server/src/engine.rs`: room state, phase progression, scoring, prompt assignment, settings validation, reconnect/dropout rules, and engine unit tests.
+- `server/src/engine.rs`: room state, phase progression, scoring, prompt assignment, settings validation, reconnect/dropout rules.
+- `server/src/engine/tests.rs`: engine unit tests.
 - `server/src/main.rs`: HTTP/WebSocket routes, connection authorization, static serving/cache headers, health response, room maintenance, and integration-style WebSocket tests.
 - `server/src/protocol.rs`: Rust protocol types and gameplay constants.
-- `client/src/main.tsx`: React entry for TV/player rendering, room joining, reconnect behavior, turn submission, voting, and dynamic status text.
-- `client/src/app/`: GameProvider (WebSocket/state) and phase router.
-- `client/src/views/`: Display and player phase screens.
+- `server/src/prompts.rs`: prompt packs (`safe-party`, `party-chaos`).
+- `client/src/main.tsx`: React mount + service worker registration only.
+- `client/src/app/GameProvider.tsx`: WebSocket, room join/reconnect, submissions, voting, shared client state.
+- `client/src/app/App.tsx`: role + phase router.
+- `client/src/views/`: display and player phase screens (including spectator watch).
 - `client/src/protocol.ts`: TypeScript protocol types and runtime guards for server messages.
-- `client/src/drawing.ts`: drawing pad, stroke capture, stroke simplification, canvas rendering, and drawing limits.
+- `client/src/drawing.ts`: drawing pad, stroke capture, simplification, rendering, limits.
+- `client/src/spectator.ts`, `polish.ts`, `hooks/useRevealStage.ts`: spectator helpers and results reveal staging.
+- `client/src/design/`: CSS tokens and glass styles (see `docs/design.md`).
 - `client/e2e/`: Playwright coverage for full rounds, device compatibility, polish, and PWA cache behavior.
 
 ## Game Flow
@@ -39,6 +57,19 @@ Draw Party is an open-source Drawful-style party game for a TV/display browser a
 4. Voting: non-artist players choose the real prompt while the artist watches. Reactions remain available.
 5. Results: the client stages the reveal (votes → correct answer → deltas); the engine auto-advances after `resultsSeconds` unless the display Continues early. Scoring includes nobody-found and perfect-truth bonuses.
 6. Final Scores: after the configured round count, the display shows the podium (with titles) and can start again or export a share card.
+
+Scoring values and reconnect rules: [docs/architecture.md](docs/architecture.md).
+
+## When Changing X, Also Update Y
+
+| If you change… | Also update… |
+|----------------|--------------|
+| `server/src/protocol.rs` | `client/src/protocol.ts`, `docs/protocol.md`, relevant tests |
+| Scoring / phases / reconnect | `server/src/engine/tests.rs`, `docs/architecture.md` |
+| Design tokens or glass rules | `client/src/design/**`, `docs/design.md` |
+| Client phase ownership or routes | `docs/client-ui.md` (do not move phase authority to the client) |
+| Env / deploy / PWA cache | `docs/deployment.md`, README deploy section if the quick start changes |
+| Validation commands | `docs/contributing.md`, `AGENTS.md`, CI |
 
 ## Validation
 
@@ -56,7 +87,7 @@ npm run e2e
 
 For narrow changes, match validation to blast radius:
 
-- Engine or scoring changes: `cargo test --manifest-path server/Cargo.toml`, plus targeted tests in `server/src/engine.rs`.
+- Engine or scoring changes: `cargo test --manifest-path server/Cargo.toml`, plus targeted tests in `server/src/engine/tests.rs`.
 - WebSocket, reconnect, health, or static-serving changes: `cargo test --manifest-path server/Cargo.toml`, plus relevant tests in `server/src/main.rs`.
 - Client logic or protocol changes: `npm --prefix client test -- --run` and `npm --prefix client run typecheck`.
 - UI/layout/touch changes: relevant Playwright e2e coverage, including mobile-sized phone contexts.
@@ -71,6 +102,7 @@ For narrow changes, match validation to blast radius:
 - Keep client protocol guards strict; unknown or malformed server messages should not mutate UI state.
 - Avoid complex drawing features unless they directly improve the simple party flow.
 - Prefer small, reviewable changes with tests close to the changed behavior.
+- Do not duplicate this file into `CLAUDE.md` / Copilot instruction forks; keep one canonical agent doc.
 
 ## Deployment Notes
 
@@ -78,3 +110,4 @@ For narrow changes, match validation to blast radius:
 - Service worker and static asset behavior must keep live game routes network-first: `/api/*` and `/ws` should not be cached.
 - Railway deployments can expose commit, branch, deployment, and environment metadata through `/api/health`.
 - Do not assume static-only hosting is sufficient for current gameplay; the WebSocket server is required.
+- Env catalog and smoke steps: [docs/deployment.md](docs/deployment.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Contribution guide: [docs/contributing.md](docs/contributing.md).
+
+For agents: start at [AGENTS.md](AGENTS.md), then open only the deep dive you need from [docs/](docs/README.md).

--- a/README.md
+++ b/README.md
@@ -48,19 +48,11 @@ Then open `http://localhost:3000`. Root `package.json` also exposes `client:test
 
 ## Validation
 
+Full CI matrix, blast-radius table, and e2e notes: [docs/contributing.md](docs/contributing.md#validation).
+
 ```bash
-cargo fmt --check --manifest-path server/Cargo.toml
-cargo clippy --manifest-path server/Cargo.toml --all-targets -- -D warnings
-cargo test --manifest-path server/Cargo.toml
-npm --prefix client run typecheck
-npm --prefix client test -- --run
-npm --prefix client run build
-npm run e2e
+npm run test   # or follow the contributing matrix for a narrower PR
 ```
-
-`npm run e2e` builds the client, starts the Rust server on `127.0.0.1:3100`, and runs Playwright against the built app. Set `E2E_PORT` to use a different local port, or set `E2E_BASE_URL` to run the same tests against an already-running deployment.
-
-The E2E suite covers one TV and three isolated phone browser contexts through drawing, guessing, voting, results, and the next round transition. It also checks that `/sw.js` is served as JavaScript, includes the app-shell cache behavior, leaves `/api/*` routes uncached, and keeps browser routes such as `/join/:roomCode` on the SPA shell.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -11,26 +11,40 @@ The TV browser creates a room and shows a join code. Each player joins from a ph
 - Drawings are compact vector stroke documents, not image data URLs.
 - Rooms are in-memory and ephemeral. No accounts or database are required for v1.
 
-## Local Development
+## Documentation
 
-Install Rust, Node.js, and npm first.
+| Doc | Audience |
+|-----|----------|
+| [AGENTS.md](AGENTS.md) | AI agents (canonical map + rules) |
+| [docs/](docs/README.md) | Architecture, protocol, design, deploy, contributing |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to develop and validate changes |
+| [SECURITY.md](SECURITY.md) | Vulnerability reporting |
+
+## Prerequisites
+
+- Node.js 22
+- Stable Rust (`clippy`, `rustfmt`)
+- npm
+
+## Local Development
 
 ```bash
 npm --prefix client ci
 npm --prefix client run e2e:install
+npm run server:dev
+npm run client:dev
+```
+
+The Vite dev server proxies `/ws` and `/api` to the Rust server on port `3000`. Open the Vite URL on the TV/display; phones join with the QR/code.
+
+Production-like local run (server serves the built client):
+
+```bash
 npm --prefix client run build
 cargo run --manifest-path server/Cargo.toml
 ```
 
-Then open `http://localhost:3000` on the TV/display browser. Phones join with the QR/code shown on the display.
-
-For client-only development:
-
-```bash
-npm --prefix client run dev
-```
-
-The Vite dev server proxies `/ws` and `/api` to the Rust server on port `3000`.
+Then open `http://localhost:3000`. Root `package.json` also exposes `client:test`, `client:typecheck`, `server:test`, `e2e`, and `test`.
 
 ## Validation
 
@@ -50,7 +64,7 @@ The E2E suite covers one TV and three isolated phone browser contexts through dr
 
 ## Deployment
 
-The Rust server serves the built client from `client/dist`.
+The Rust server serves the built client from `client/dist`. Env vars, Docker, Railway health metadata, and PWA cache rules: [docs/deployment.md](docs/deployment.md).
 
 ```bash
 npm --prefix client ci
@@ -59,19 +73,17 @@ cargo build --manifest-path server/Cargo.toml --release
 DRAW_PARTY_STATIC_DIR=client/dist ./target/release/draw-party-server
 ```
 
-`GET /api/health` returns server status plus deploy metadata when the host provides it. Railway GitHub deploys expose values such as `RAILWAY_GIT_COMMIT_SHA`, `RAILWAY_GIT_BRANCH`, `RAILWAY_DEPLOYMENT_ID`, and `RAILWAY_ENVIRONMENT_NAME`; local runs can set `GIT_SHA` and `GIT_BRANCH` for the same smoke-proof flow. `GET /` opens the TV display. `GET /join/:roomCode` opens the phone join flow.
+`GET /api/health` returns server status plus deploy metadata when the host provides it. `GET /` opens the TV display. `GET /join/:roomCode` opens the phone join flow.
 
-The production server should serve `client/dist` as its static directory so the copied `sw.js`, `manifest.webmanifest`, and hashed assets are all available from the same origin. The service worker caches the app shell and built assets for browser/PWA resilience, but intentionally bypasses `/api/*` and `/ws` so live game state and WebSocket traffic stay network-first.
-
-GitHub Actions runs Rust formatting, clippy, Rust tests, client typecheck, Vitest, client build, and Playwright on pull requests and pushes to `main`.
-
-For Railway release verification, confirm the deployed health response reports the expected merged commit and then run the browser flow against the public service:
+For Railway release verification:
 
 ```bash
 curl https://drawparty.up.railway.app/api/health
 E2E_BASE_URL=https://drawparty.up.railway.app npm run e2e
 ```
 
+GitHub Actions runs Rust formatting, clippy, Rust tests, client typecheck, Vitest, client build, and Playwright on pull requests and pushes to `main`.
+
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+Draw Party v1 is an ephemeral party game: no user accounts, no database, and no persistent room history. Rooms live in server memory and expire after participants disconnect and the room TTL passes.
+
+## Reporting a vulnerability
+
+Please report security issues through [GitHub Security Advisories](https://github.com/astraldrift/draw-party-game/security/advisories/new) for this repository when available. Do not open a public issue for exploitable vulnerabilities.
+
+Include:
+
+- A clear description of the issue and impact
+- Steps to reproduce or a proof of concept
+- Affected commit / deployment URL if known
+
+## Scope notes
+
+- The WebSocket game server and static asset serving are in scope.
+- Misconfiguration of third-party hosts (for example open CORS on unrelated services) is generally out of scope unless it is caused by this project's defaults.
+- Social engineering, physical attacks, and denial-of-service flood testing against production without prior coordination are out of scope.
+
+We will acknowledge reports as quickly as practical and coordinate a fix before any public disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Draw Party v1 is an ephemeral party game: no user accounts, no database, and no 
 
 ## Reporting a vulnerability
 
-Please report security issues through [GitHub Security Advisories](https://github.com/astraldrift/draw-party-game/security/advisories/new) for this repository when available. Do not open a public issue for exploitable vulnerabilities.
+Please report security issues through [GitHub Security Advisories](https://github.com/AstralDrift/draw-party-game/security/advisories/new) for this repository when available. Do not open a public issue for exploitable vulnerabilities.
 
 Include:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# Draw Party Docs
+
+Progressive documentation for humans and AI agents. Start at the root, then open only the deep dive you need.
+
+## Start here
+
+| Audience | Read first | Then |
+|----------|------------|------|
+| Players / hosts | [../README.md](../README.md) | [deployment.md](deployment.md) if self-hosting |
+| Contributors | [contributing.md](contributing.md) | [architecture.md](architecture.md) |
+| AI agents | [../AGENTS.md](../AGENTS.md) | This index, then the topic doc below |
+
+## Topic map
+
+| Doc | When to open it |
+|-----|-----------------|
+| [architecture.md](architecture.md) | Phases, server authority, reconnect/dropout, spectators, scoring |
+| [protocol.md](protocol.md) | Constants, WebSocket messages, dual Rust/TS update rule |
+| [client-ui.md](client-ui.md) | React client tree, phase screens, non-negotiables |
+| [design.md](design.md) | Glass design system (tokens, type, motion, components) |
+| [deployment.md](deployment.md) | Env vars, Docker, Railway, PWA/cache, health smoke |
+| [contributing.md](contributing.md) | Prerequisites, scripts, validation matrix, PR expectations |
+
+## Source of truth
+
+- Game rules, phases, scoring, and reconnect behavior: Rust engine (`server/src/engine.rs`) and tests (`server/src/engine/tests.rs`)
+- Wire protocol and limits: `server/src/protocol.rs` mirrored by `client/src/protocol.ts`
+- Visual system: `docs/design.md` with CSS under `client/src/design/`
+- Agent defaults and blast-radius validation: root `AGENTS.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Architecture
+
+Draw Party is a TV display + phone controllers party game. The Rust server is authoritative for rooms, phases, deadlines, scoring, reconnects, and cleanup. The Vite + TypeScript client renders TV/player UI, captures drawings, validates server messages, and stages some presentation polish.
+
+See also: [protocol.md](protocol.md) for the wire contract.
+
+## Authority split
+
+| Concern | Owner |
+|---------|-------|
+| Room lifecycle, host token, roster, settings | Server (`server/src/engine.rs`, `server/src/main.rs`) |
+| Phase transitions and deadlines | Server engine |
+| Prompt assignment and scoring | Server engine |
+| Reconnect / dropout progress rules | Server engine |
+| WebSocket auth, static serving, `/api/health` | Server (`server/src/main.rs`) |
+| TV/phone rendering and drawing input | Client |
+| Protocol guards (reject unknown/malformed) | Client (`client/src/protocol.ts`) |
+| Results reveal staging (votes → correct → deltas) | Client (`client/src/hooks/useRevealStage.ts`, `polish.ts`) |
+| PWA shell cache (not `/api/*` or `/ws`) | Client (`client/public/sw.js`) |
+
+Do not reintroduce peer-to-peer room authority or client-owned phase transitions. The display may request Continue early during Results; the engine still owns whether and when the phase advances.
+
+## Game phases
+
+```mermaid
+stateDiagram-v2
+  [*] --> Lobby
+  Lobby --> Drawing: StartGame
+  Drawing --> Guessing: all drawings in or deadline
+  Guessing --> Voting: guesses in or deadline
+  Voting --> Results: votes in or deadline
+  Results --> Guessing: next artist turn
+  Results --> Drawing: next round
+  Results --> FinalScores: rounds complete
+  FinalScores --> Lobby: play again
+```
+
+1. **Lobby** — display creates room + QR/code; phones join; display adjusts timers/rounds/prompt pack; start when ready.
+2. **Drawing** — each connected non-spectator draws an assigned prompt and submits once they have ink.
+3. **Guessing** — one drawing at a time; non-artist players submit fake answers; reactions allowed.
+4. **Voting** — non-artists pick the real prompt; artist watches; reactions allowed.
+5. **Results** — server publishes `RoundResult`; client stages reveal; engine auto-advances after `resultsSeconds` unless display Continues early.
+6. **FinalScores** — podium after configured rounds; display can restart or export a share card.
+
+## Scoring (engine)
+
+Values live in `server/src/engine.rs` (`finish_voting`):
+
+| Event | Points |
+|-------|--------|
+| Correct vote | +200 to voter, +100 to artist |
+| Vote for a fake answer | +50 to that fake's author |
+| Nobody found it (no correct votes, eligible voters exist) | +50 to artist |
+| Perfect truth (every eligible voter picks correct) | +25 to each eligible voter |
+
+Spectators are not eligible voters. The artist is never an eligible voter for their own turn.
+
+## Reconnect and dropout
+
+- Disconnected players remain on the roster with `connected: false`.
+- Progress does not wait forever on disconnected players: once all **connected** eligible players have submitted (draw / guess / vote), the engine can advance.
+- Heartbeats and WebSocket reconnect restore `connected` without resetting room authority.
+
+## Spectators and seat limits
+
+- `MAX_PLAYERS` (8) includes spectators. Late joiners still consume a seat.
+- Mid-game joiners arrive as `PlayerPublic.spectator: true` until the next drawing round, when the engine promotes them.
+- Lobby readiness and progress panels should count **active** (non-spectator) players only. Client helpers live in `client/src/spectator.ts`.
+
+## Client vs server on Results
+
+The server decides scores and when Results ends. The client only stages presentation:
+
+- Hold → tally (votes) → correct answer → score deltas → complete
+- Timing helpers: `client/src/hooks/useRevealStage.ts` and `client/src/polish.ts`
+
+Changing reveal theater does not change scoring; changing scoring requires engine + tests updates and usually a docs touch here.
+
+## Key source map
+
+| Area | Path |
+|------|------|
+| Room/phase/scoring | `server/src/engine.rs` |
+| Engine unit tests | `server/src/engine/tests.rs` |
+| Prompt packs | `server/src/prompts.rs` |
+| HTTP/WS/static/health | `server/src/main.rs` |
+| Protocol types | `server/src/protocol.rs`, `client/src/protocol.ts` |
+| Client WS + state | `client/src/app/GameProvider.tsx` |
+| Phase router | `client/src/app/App.tsx` |
+| Display / player screens | `client/src/views/` |
+| Drawing pad | `client/src/drawing.ts` |

--- a/docs/client-ui.md
+++ b/docs/client-ui.md
@@ -1,10 +1,10 @@
-# Client UI (Glass Rewrite)
+# Client UI
 
-## Status
+React + TypeScript Apple-glass UI is the sole client entry. All phases are implemented against the Rust protocol.
 
-Branch: `micah/glass-ui-rewrite`
+See [design.md](design.md) for the visual system and [architecture.md](architecture.md) for authority boundaries.
 
-React + TypeScript Apple-glass UI is the sole client entry. All phases are implemented against the Rust protocol:
+## Phase coverage
 
 1. **Lobby** — TV create/QR/settings/start + phone join/wait
 2. **Drawing** — phone stroke pad + TV progress
@@ -12,47 +12,35 @@ React + TypeScript Apple-glass UI is the sole client entry. All phases are imple
 4. **Results** — staged reveal (hold → tally → correct → deltas → complete) + Continue gate
 5. **Final Scores** — podium, titles, share card
 
-Legacy `main.ts` / monolithic `style.css` / DOM dual-stack are removed.
-
 ## Architecture
 
 ```
 client/src/
-  main.tsx                 # React entry
+  main.tsx                 # React mount + service worker register
   app/App.tsx              # Role + phase router
   app/GameProvider.tsx     # WebSocket + room state (server-authoritative)
   design/                  # Tokens + base + layout + motion + drawing styles
   components/ui/           # Glass primitives + results/scores/progress
   hooks/useRevealStage.ts  # Results reveal staging timing + React hook
   spectator.ts             # Active/playing/spectator roster helpers
-  views/player/SpectatorWatch.tsx  # Mid-game watch-only phone UI
-  # shared contracts:
+  views/display/           # TV phase screens
+  views/player/            # Phone phase screens + SpectatorWatch
+  # shared contracts / helpers:
   protocol.ts, net.ts, drawing.ts, time.ts, polish.ts, sound.ts, share-card.ts
 ```
 
 Mid-game joiners become `PlayerPublic.spectator` until the next drawing round (server promotes). Lobby readiness and progress panels count active (non-spectator) players only.
 
-## Non-negotiables (preserved)
+## Non-negotiables
 
 - URLs: `/` display, `/join/:code` player
 - Rust server authority; client does not own phase transitions
 - Stroke documents via `DrawingPad` (1024×768)
 - PWA `sw.js` network-first for `/api/*` and `/ws`
 - Protocol guards in `protocol.ts`
-
-## Design system
-
-See root `DESIGN.md`. All client CSS lives under `design/` (tokens, base, components, drawing, layout, motion).
-Buttons use `btn` / `btn--primary|secondary|ghost` / `btn--wide` only.
+- All client CSS under `design/` (tokens, base, components, drawing, layout, motion)
+- Buttons use `btn` / `btn--primary|secondary|ghost` / `btn--wide` only
 
 ## Validation
 
-```bash
-cargo fmt --check --manifest-path server/Cargo.toml
-cargo clippy --manifest-path server/Cargo.toml --all-targets -- -D warnings
-cargo test --manifest-path server/Cargo.toml
-npm --prefix client run typecheck
-npm --prefix client test -- --run
-npm --prefix client run build
-npm run e2e
-```
+For UI/layout/touch changes, prefer relevant Playwright coverage under `client/e2e/` (include mobile-sized phone contexts). Full matrix is in [contributing.md](contributing.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Thanks for helping with Draw Party. Keep changes small, reviewable, and tested near the behavior you touch.
+
+## Prerequisites
+
+- **Node.js 22** (matches CI)
+- **Stable Rust** with `clippy` and `rustfmt`
+- npm (comes with Node)
+
+## Repo layout
+
+| Path | Role |
+|------|------|
+| `server/` | Authoritative Rust game server |
+| `client/` | Vite + React + TypeScript TV/player app |
+| `docs/` | Progressive documentation |
+| Root `package.json` | Thin script facade (`client:dev`, `server:dev`, `e2e`, `test`) |
+
+Prefer root scripts when they exist; app packages still live under `client/`.
+
+## Local development
+
+```bash
+npm --prefix client ci
+npm --prefix client run e2e:install   # Playwright browsers, once
+npm run server:dev                    # Rust server on :3000
+npm run client:dev                    # Vite; proxies /ws and /api to :3000
+```
+
+Open the display at the Vite URL or `http://localhost:3000` after a full build. See [deployment.md](deployment.md) for production-like runs.
+
+## Validation
+
+Full matrix (same as CI):
+
+```bash
+cargo fmt --check --manifest-path server/Cargo.toml
+cargo clippy --manifest-path server/Cargo.toml --all-targets -- -D warnings
+cargo test --manifest-path server/Cargo.toml
+npm --prefix client run typecheck
+npm --prefix client test -- --run
+npm --prefix client run build
+npm run e2e
+```
+
+Match blast radius for narrow PRs:
+
+| Change | Validate with |
+|--------|----------------|
+| Engine / scoring | `cargo test --manifest-path server/Cargo.toml` (+ engine tests) |
+| WebSocket / reconnect / health / static | `cargo test` (incl. `main.rs` tests) |
+| Client logic / protocol | `npm --prefix client test -- --run` + typecheck |
+| UI / layout / touch | Relevant Playwright e2e (include mobile phone contexts) |
+| Protocol constants/messages | Both Rust and TS sides + tests above |
+| Docs only | Link walk + constant accuracy vs code |
+
+`npm run e2e` builds the client, starts the Rust server on `127.0.0.1:3100`, and runs Playwright. Set `E2E_PORT` or `E2E_BASE_URL` as needed.
+
+## Design and protocol
+
+- UI work: follow [design.md](design.md) and [client-ui.md](client-ui.md). CSS belongs under `client/src/design/`.
+- Protocol work: update both `server/src/protocol.rs` and `client/src/protocol.ts`, then [protocol.md](protocol.md).
+- Architecture / scoring: keep [architecture.md](architecture.md) aligned with the engine.
+
+## Pull requests
+
+- Prefer focused PRs with tests close to the changed behavior.
+- Use the GitHub PR template checklist.
+- Do not reintroduce client-owned phase transitions or peer-to-peer room authority.
+- Spectators consume `MAX_PLAYERS` seats; disconnected players must not block progress once connected eligible players have submitted.
+
+## Security
+
+See [../SECURITY.md](../SECURITY.md). v1 is ephemeral (no accounts or database).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,69 @@
+# Deployment
+
+The Rust server serves the built client from `client/dist`. Static-only hosting is not enough: gameplay requires the WebSocket server.
+
+## Environment variables
+
+| Variable | Purpose | Default / notes |
+|----------|---------|-----------------|
+| `DRAW_PARTY_BIND` | Listen address | `127.0.0.1:3000` locally; Docker sets `0.0.0.0:3000` |
+| `DRAW_PARTY_STATIC_DIR` | Built client directory | `client/dist` (Docker: `/app/client/dist`) |
+| `RAILWAY_GIT_COMMIT_SHA` / `GIT_SHA` | Health `gitSha` | Optional |
+| `RAILWAY_GIT_BRANCH` / `GIT_BRANCH` | Health `gitBranch` | Optional |
+| `RAILWAY_DEPLOYMENT_ID` / `DEPLOYMENT_ID` | Health `deploymentId` | Optional |
+| `RAILWAY_ENVIRONMENT_NAME` / `ENVIRONMENT_NAME` | Health `environmentName` | Optional |
+
+E2E helpers (client scripts, not the game server):
+
+| Variable | Purpose |
+|----------|---------|
+| `E2E_PORT` | Local server port for Playwright (default `3100`) |
+| `E2E_BASE_URL` | Run e2e against an already-running deployment |
+
+## Local production-like run
+
+```bash
+npm --prefix client ci
+npm --prefix client run build
+cargo build --manifest-path server/Cargo.toml --release
+DRAW_PARTY_STATIC_DIR=client/dist ./target/release/draw-party-server
+```
+
+Open `http://localhost:3000` for the TV display. Phones use the QR/code or `/join/:roomCode`.
+
+## Docker
+
+Root `Dockerfile` builds the client (Node 22), builds the release server (Rust), and runs with:
+
+- `DRAW_PARTY_STATIC_DIR=/app/client/dist`
+- `DRAW_PARTY_BIND=0.0.0.0:3000`
+- port `3000` exposed
+
+## HTTP routes
+
+| Route | Role |
+|-------|------|
+| `GET /` | TV display SPA |
+| `GET /join/:roomCode` | Phone join SPA shell |
+| `GET /api/health` | Liveness + optional deploy metadata |
+| `GET /ws` (upgrade) | Game WebSocket |
+
+## PWA and caching
+
+Production should serve `client/dist` from the same origin as `/ws` and `/api/*` so `sw.js`, `manifest.webmanifest`, and hashed assets share origin.
+
+The service worker may cache the app shell and built assets. It must keep live game routes **network-first**:
+
+- do not cache `/api/*`
+- do not cache `/ws`
+
+## Railway smoke
+
+Confirm the deployed commit, then optionally run e2e against the public URL:
+
+```bash
+curl https://<your-service>/api/health
+E2E_BASE_URL=https://<your-service> npm run e2e
+```
+
+GitHub Actions runs formatting, clippy, Rust tests, client typecheck/Vitest/build, and Playwright on pull requests and pushes to `main`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,12 +1,14 @@
 # Draw Party Design System
 
+Implementation lives under `client/src/design/` (tokens, base, components, drawing, layout, motion). This document is the product design source of truth; keep CSS tokens aligned when either side changes.
+
 ## 1. Atmosphere & Identity
 
 Draw Party should feel like a living-room apple-glass night: soft translucent surfaces floating over a deep charcoal stage, with quiet blue accents and couch-readable type. The signature is frosted glass — hairline borders, gentle blur, and layered depth — never neon arcade chrome, purple SaaS gradients, cream/terracotta editorial, or newspaper density.
 
 ## 2. Color
 
-Party play is dark-first (TV living rooms). Tokens below are the product palette; light mode is not required for v1 glass rewrite.
+Party play is dark-first (TV living rooms). Tokens below are the product palette; light mode is not required for v1.
 
 ### Palette
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -57,7 +57,7 @@ Important fields:
 | `joinRoom` | Player joins with `roomCode` + `name` |
 | `setName` | Rename in lobby |
 | `updateRoomSettings` | Display updates timers/rounds/pack |
-| `startGame` | Display starts |
+| `startGame` | Display starts the game, Continues after results, or Play Again from final scores |
 | `submitDrawing` | `turnToken` + `drawing` |
 | `submitGuess` | `turnToken` + `guess` |
 | `submitVote` | `turnToken` + `optionId` |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,91 @@
+# Protocol
+
+Wire contract between the Rust server and TypeScript client. **Edit both sides** when changing messages or constants:
+
+- `server/src/protocol.rs`
+- `client/src/protocol.ts` (types + runtime guards)
+
+JSON uses `camelCase` field names (`serde(rename_all = "camelCase")`). Message enums are tagged with `"type"`.
+
+After protocol changes, update this doc and run client typecheck/tests plus `cargo test`.
+
+## Gameplay constants
+
+From `server/src/protocol.rs` (defaults and limits):
+
+| Constant | Value | Notes |
+|----------|-------|-------|
+| `CANVAS_WIDTH` × `CANVAS_HEIGHT` | 1024 × 768 | Logical stroke canvas |
+| `MAX_PLAYERS` | 8 | Includes spectators |
+| `MIN_PLAYERS` | 1 | Engine allows; party UX expects more |
+| `DEFAULT_TOTAL_ROUNDS` | 5 | Range 1–12 |
+| `DEFAULT_DRAW_SECONDS` | 90 | Range 15–300 |
+| `DEFAULT_GUESS_SECONDS` | 45 | Range 10–180 |
+| `DEFAULT_VOTE_SECONDS` | 30 | Range 10–120 |
+| `DEFAULT_RESULTS_SECONDS` | 12 | Range 5–30 |
+| `DEFAULT_PROMPT_PACK_ID` | `safe-party` | Also `party-chaos` |
+| `ROOM_TTL_MS` | 3 hours | After all participants disconnect |
+| `REACTION_COOLDOWN_MS` | 1500 | Per player |
+| `ALLOWED_REACTIONS` | 😂 😱 🔥 👏 | Server-enforced allowlist |
+| `MAX_STROKES` | 220 | Per drawing |
+| `MAX_POINTS_PER_STROKE` | 180 | Per stroke |
+| `MAX_NAME_LEN` | 24 | |
+| `MAX_GUESS_LEN` | 60 | |
+
+Room settings (`RoomSettings`) carry rounds and timer fields plus `promptPackId`.
+
+## Roles and phases
+
+- **Roles:** `display` | `player`
+- **Phases:** `lobby` | `drawing` | `guessing` | `voting` | `results` | `finalScores`
+
+## Snapshot
+
+`RoomSnapshot` is the shared public room state (code, phase, players, settings, timers, turn token, deadlines, current artist/drawing, voting options, round result, final scores, submission id lists). Clients should treat snapshots from the server as authoritative.
+
+Important fields:
+
+- `turnToken` — submissions must match the current turn
+- `deadlineMs` / `serverNowMs` — client syncs countdowns to server time
+- `players[].spectator` — mid-game watchers until promoted
+
+## Client → server (`ClientMessage`)
+
+| Type | Purpose |
+|------|---------|
+| `createRoom` | Display creates a room |
+| `joinRoom` | Player joins with `roomCode` + `name` |
+| `setName` | Rename in lobby |
+| `updateRoomSettings` | Display updates timers/rounds/pack |
+| `startGame` | Display starts |
+| `submitDrawing` | `turnToken` + `drawing` |
+| `submitGuess` | `turnToken` + `guess` |
+| `submitVote` | `turnToken` + `optionId` |
+| `sendReaction` | `emoji` (allowlisted) |
+| `heartbeat` | Keepalive / time sync |
+| `leaveRoom` | Leave |
+
+## Server → client (`ServerMessage`)
+
+| Type | Purpose |
+|------|---------|
+| `roomCreated` | Snapshot + `hostToken` |
+| `roomSnapshot` | Full state refresh |
+| `phaseChanged` | Phase transition snapshot |
+| `promptAssigned` | Private prompt for a player |
+| `playerListChanged` | Roster update |
+| `drawingReveal` | Artist drawing for guess/vote |
+| `votingOptions` | Shuffled options (correct flag only where allowed) |
+| `roundResult` | Scores and breakdown |
+| `finalScores` | End-of-game podium data |
+| `reactionBurst` | Ephemeral reaction |
+| `pong` | Heartbeat reply with `nowMs` |
+| `error` | `code` + `message` |
+
+## Client guards
+
+`client/src/protocol.ts` validates inbound messages. Unknown or malformed server messages must not mutate UI state. Prefer failing closed over optimistic local phase ownership.
+
+## Drawings
+
+Drawings are compact vector stroke documents (`DrawingDoc`: width, height, strokes of color/size/points), not image data URLs. Limits above are enforced on the server; the pad also respects them in `client/src/drawing.ts`.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -19,10 +19,10 @@ From `server/src/protocol.rs` (defaults and limits):
 | `MAX_PLAYERS` | 8 | Includes spectators |
 | `MIN_PLAYERS` | 1 | Engine allows; party UX expects more |
 | `DEFAULT_TOTAL_ROUNDS` | 5 | Range 1–12 |
-| `DEFAULT_DRAW_SECONDS` | 90 | Range 15–300 |
-| `DEFAULT_GUESS_SECONDS` | 45 | Range 10–180 |
-| `DEFAULT_VOTE_SECONDS` | 30 | Range 10–120 |
-| `DEFAULT_RESULTS_SECONDS` | 12 | Range 5–30 |
+| `DEFAULT_DRAW_SECONDS` | 75 | Range 15–300 |
+| `DEFAULT_GUESS_SECONDS` | 40 | Range 10–180 |
+| `DEFAULT_VOTE_SECONDS` | 25 | Range 10–120 |
+| `DEFAULT_RESULTS_SECONDS` | 10 | Range 5–30 |
 | `DEFAULT_PROMPT_PACK_ID` | `safe-party` | Also `party-chaos` |
 | `ROOM_TTL_MS` | 3 hours | After all participants disconnect |
 | `REACTION_COOLDOWN_MS` | 1500 | Per player |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorganizes Draw Party docs for humans and AI agents: progressive `docs/` tree, refreshed canonical `AGENTS.md`, path-scoped Cursor rules, and lightweight OSS scaffolding.

## What changed

- Added `docs/` with index, architecture, protocol, deployment, contributing, design, and client-ui deep dives
- Moved root `DESIGN.md` / `CLIENT_UI.md` into `docs/` (dropped stale glass-rewrite branch status)
- Refreshed `AGENTS.md` source map (`GameProvider`, `engine/tests.rs`, dual-update table) and linked the docs index
- Upgraded `README.md` with prerequisites, doc links, and thinner deploy section
- Added path-scoped Cursor rules for server authority, protocol dual-update, and design
- Added `CONTRIBUTING.md`, `SECURITY.md`, PR template, and Dependabot

## Test plan

- [x] Docs-only change set (no server/client code)
- [x] Grep for stale `DESIGN.md` / `CLIENT_UI.md` references
- [x] Protocol defaults and scoring values checked against `protocol.rs` / `engine.rs`
- [x] Link walk: README → AGENTS → docs index → topic docs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4925293-bf32-4eec-8755-3f21a22360e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4925293-bf32-4eec-8755-3f21a22360e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

