### PR TITLE
docs: fix FinalScores play-again transition

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ See also: [protocol.md](protocol.md) for the wire contract.
 | WebSocket auth, static serving, `/api/health` | Server (`server/src/main.rs`) |
 | TV/phone rendering and drawing input | Client |
 | Protocol guards (reject unknown/malformed) | Client (`client/src/protocol.ts`) |
-| Results reveal staging (votes → correct → deltas) | Client (`client/src/hooks/useRevealStage.ts`, `polish.ts`) |
+| Results reveal staging (votes → correct → deltas) | Client (`client/src/hooks/useRevealStage.ts`, `client/src/polish.ts`) |
 | PWA shell cache (not `/api/*` or `/ws`) | Client (`client/public/sw.js`) |
 
 Do not reintroduce peer-to-peer room authority or client-owned phase transitions. The display may request Continue early during Results; the engine still owns whether and when the phase advances.
@@ -32,7 +32,7 @@ stateDiagram-v2
   Results --> Guessing: next artist turn
   Results --> Drawing: next round
   Results --> FinalScores: rounds complete
-  FinalScores --> Lobby: play again
+  FinalScores --> Drawing: play again
 ```
 
 1. **Lobby** — display creates room + QR/code; phones join; display adjusts timers/rounds/prompt pack; start when ready.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up from review of #48: Play Again does not return to Lobby.

`handle_start_or_advance` treats `FinalScores` like Lobby and calls `start_drawing_round`, so the diagram must be `FinalScores → Drawing`.

Also qualifies `polish.ts` as `client/src/polish.ts` in the authority table.

## Test plan

- [x] Checked against `server/src/engine.rs` `handle_start_or_advance`
- [x] Docs-only change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4925293-bf32-4eec-8755-3f21a22360e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4925293-bf32-4eec-8755-3f21a22360e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

