### PR TITLE
Polish party UX: share card, lobby rename, drawing tools

### DIFF
--- a/client/e2e/polish.e2e.ts
+++ b/client/e2e/polish.e2e.ts
@@ -121,10 +121,19 @@ test('large-phone lobby presents player-ready hierarchy without clipping', async
     await expect(ava.locator('.player-lobby-card')).toBeVisible();
     await expect(ava.locator('.mini-room-code')).toHaveText(roomCode);
     await expect(ava.getByText('Party is ready')).toBeVisible();
+    await expect(ava.getByText('Invite 1 more for better voting.')).toBeVisible();
+    await expect(ava.getByRole('button', { name: 'Edit name' })).toBeVisible();
     await expect(ava.locator('.players-panel')).toBeVisible();
     await expect(bo.locator('.player-lobby-card')).toBeVisible();
     await expect(tv.getByRole('button', { name: 'Start Game' })).toBeEnabled();
+    await expect(tv.getByText('2 ready — playable now, best with 3+ for votes and fakes.')).toBeVisible();
     await expectNoHorizontalOverflow(ava);
+
+    await ava.getByRole('button', { name: 'Edit name' }).click();
+    await ava.getByLabel('Your name').fill('Ava Renamed');
+    await ava.getByRole('button', { name: 'Save name' }).click();
+    await expect(ava.getByText("Ava Renamed, you're in")).toBeVisible();
+    await expect(tv.getByText('Ava Renamed')).toBeVisible();
 
     const lobbyBox = await ava.locator('.player-lobby-card').boundingBox();
     const playersBox = await ava.locator('.players-panel').boundingBox();
@@ -177,6 +186,10 @@ test('phone drawing screen prioritizes canvas before controls on mobile', async 
     await expect(ava.locator('.submit-help')).toHaveText('Ready when you are.');
     await ava.locator('.tools-summary').click();
     await expect(ava.locator('.draw-toolbar')).toBeVisible();
+    await expect(ava.getByRole('button', { name: /eraser/i })).toBeVisible();
+    await ava.getByRole('button', { name: 'Clear drawing' }).click();
+    await expect(ava.getByRole('button', { name: 'Tap again to clear drawing' })).toBeVisible();
+    await expect(ava.locator('.draw-status')).toHaveText('Tap clear again to erase everything.');
   } finally {
     await Promise.all(contexts.map((context) => context.close()));
   }
@@ -449,6 +462,7 @@ test('one-round finale renders podium and scores without overflow', async ({ bas
     await expect(tv.getByRole('button', { name: 'Play Again' })).toBeVisible();
     await expect(tv.getByText('Don’t stop now')).toBeVisible();
     await expect(tv.locator('.spotlight-button')).toBeVisible();
+    await expect(tv.getByRole('button', { name: /Podium/ })).toBeVisible();
     await expect(tv.locator('.podium-place')).toHaveCount(2);
     await expect(tv.locator('.score-row')).toHaveCount(2);
 
@@ -463,6 +477,7 @@ test('one-round finale renders podium and scores without overflow', async ({ bas
       await expect(player.locator('.scores-panel')).toBeVisible();
       await expect(player.locator('.winner-callout')).toBeVisible();
       await expect(player.locator('.podium-place')).toHaveCount(2);
+      await expect(player.getByRole('button', { name: /Podium/ })).toBeVisible();
       await expectNoHorizontalOverflow(player);
       const playerScoresPanel = await player.locator('.scores-panel').boundingBox();
       if (!playerScoresPanel) {

--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -338,6 +338,12 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       const safeName = name.trim() || 'Player';
       localStorage.setItem('draw-party-name', safeName);
       setPlayerName(safeName);
+      setPendingJoin((current) => {
+        if (!current) {
+          return current;
+        }
+        return { ...current, name: safeName };
+      });
       send({ type: 'setName', name: safeName });
       haptic(8);
     },

--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -54,6 +54,7 @@ interface GameContextValue {
   clearError: () => void;
   setSelectedVote: (vote: { turnToken: number; optionId: string } | null) => void;
   joinRoom: (roomCode: string, name: string) => void;
+  setName: (name: string) => void;
   cancelJoin: () => void;
   send: (message: ClientMessage) => void;
   updateSettings: (settings: RoomSettings) => void;
@@ -332,6 +333,17 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
     [connect, haptic]
   );
 
+  const setName = useCallback(
+    (name: string) => {
+      const safeName = name.trim() || 'Player';
+      localStorage.setItem('draw-party-name', safeName);
+      setPlayerName(safeName);
+      send({ type: 'setName', name: safeName });
+      haptic(8);
+    },
+    [haptic, send]
+  );
+
   const cancelJoin = useCallback(() => {
     setPendingJoin(null);
     pendingJoinRef.current = null;
@@ -378,6 +390,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       clearError: () => setErrorMessage(''),
       setSelectedVote,
       joinRoom,
+      setName,
       cancelJoin,
       send,
       updateSettings,
@@ -401,6 +414,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       soundOn,
       reactionBursts,
       joinRoom,
+      setName,
       cancelJoin,
       send,
       updateSettings,

--- a/client/src/components/ui/PlayerList.tsx
+++ b/client/src/components/ui/PlayerList.tsx
@@ -12,7 +12,7 @@ export function PlayerList({ players, showScores = false }: PlayerListProps): Re
 
   return (
     <div className="player-list">
-      {players.map((player, index) => {
+      {players.map((player) => {
         const statusPill = player.spectator
           ? player.connected
             ? 'spectating'
@@ -26,7 +26,6 @@ export function PlayerList({ players, showScores = false }: PlayerListProps): Re
           <div
             key={player.id}
             className={`player-row ${player.connected ? 'online' : 'offline'}${player.spectator ? ' is-spectator' : ''}`}
-            style={{ ['--row-index' as string]: index }}
           >
             <span className="player-name">{player.name}</span>
             <span className={`pill${player.spectator ? ' spectator-pill' : ''}`}>{statusPill}</span>

--- a/client/src/components/ui/ProgressPanel.tsx
+++ b/client/src/components/ui/ProgressPanel.tsx
@@ -87,7 +87,7 @@ export function ProgressPanel({
       </div>
         <p className="muted">{progressWaitingText(phase, waitingNames)}</p>
       <div className="player-list submission-list">
-        {players.map((player, index) => {
+        {players.map((player) => {
           const artist = phase !== 'drawing' && player.id === snapshot.currentArtistId;
           const submitted = submittedIds.includes(player.id);
           const state = !player.connected
@@ -101,7 +101,6 @@ export function ProgressPanel({
             <div
               key={player.id}
               className={`player-row submission-row ${player.connected ? 'online' : 'offline'} is-${state}`}
-              style={{ ['--row-index' as string]: index }}
             >
               <span className="player-name">{player.name}</span>
               <span className={`pill status-pill status-${state}`}>

--- a/client/src/components/ui/ScoresPanel.tsx
+++ b/client/src/components/ui/ScoresPanel.tsx
@@ -1,7 +1,7 @@
 import { finalWinnerText, podiumTitles } from '../../polish';
 import type { ClientRole } from '../../app/GameProvider';
 import type { ScoreEntry } from '../../protocol';
-import { exportShareCard } from '../../share-card';
+import { exportShareCard, podiumShareLabel } from '../../share-card';
 import { Button } from './Button';
 import { Confetti } from './Confetti';
 import { GlassPanel } from './GlassPanel';
@@ -28,6 +28,7 @@ export function ScoresPanel({
   const listedScores = podium && role === 'player' ? scores.slice(3) : scores;
   const rankOffset = podium && role === 'player' ? 3 : 0;
   const titles = new Map(podiumTitles(scores).map((entry) => [entry.playerId, entry.title]));
+  const shareLabel = podiumShareLabel();
 
   return (
     <GlassPanel className="scores-panel" id="scores-panel">
@@ -71,7 +72,7 @@ export function ScoresPanel({
           })}
         </div>
       ) : null}
-      {podium && role === 'display' ? (
+      {podium ? (
         <Button
           variant="secondary"
           wide
@@ -84,7 +85,7 @@ export function ScoresPanel({
             });
           }}
         >
-          Share Podium Card
+          {shareLabel}
         </Button>
       ) : null}
     </GlassPanel>

--- a/client/src/design/base.css
+++ b/client/src/design/base.css
@@ -164,19 +164,6 @@ button:disabled {
   margin-bottom: var(--space-6);
 }
 
-.brand-mark {
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: clamp(1.35rem, 2.4vw, 2rem);
-  letter-spacing: -0.03em;
-  line-height: 1;
-}
-
-.brand-mark span {
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-
 .connection-text,
 #connection-text {
   color: var(--text-secondary);

--- a/client/src/design/components.css
+++ b/client/src/design/components.css
@@ -122,8 +122,7 @@
   text-align: center;
 }
 
-.pill,
-.badge {
+.pill {
   display: inline-flex;
   align-items: center;
   min-height: 28px;
@@ -437,6 +436,35 @@
   font-family: var(--font-display);
   font-size: 1.5rem;
   font-weight: 700;
+}
+
+.lobby-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-3);
+}
+
+.lobby-rename-button {
+  flex-shrink: 0;
+  min-height: 40px;
+  padding: 0 var(--space-3);
+}
+
+.lobby-rename-form {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-3);
+}
+
+.lobby-rename-actions {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.player-lobby-card.is-ready {
+  border-color: rgba(48, 209, 88, 0.35);
 }
 
 .score-row,

--- a/client/src/design/drawing.css
+++ b/client/src/design/drawing.css
@@ -66,24 +66,48 @@
 }
 
 .swatch {
-  width: 40px;
-  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--touch-target, var(--touch));
+  height: var(--touch-target, var(--touch));
   border-radius: 50%;
   border: 2px solid rgba(255, 255, 255, 0.25);
+  color: var(--ink);
+  padding: 0;
 }
 
 .swatch.is-selected {
   box-shadow: 0 0 0 3px var(--accent);
 }
 
+.swatch-eraser {
+  border-color: rgba(29, 29, 31, 0.4);
+  background: #ffffff;
+}
+
+.swatch-eraser .swatch-eraser-icon {
+  pointer-events: none;
+}
+
+.swatch-eraser.is-selected {
+  box-shadow: 0 0 0 3px var(--accent);
+}
+
 .tool-button {
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--touch-target, var(--touch));
+  min-height: var(--touch-target, var(--touch));
   padding: 0 var(--space-3);
   border-radius: var(--radius-pill);
   border: 1px solid var(--border-hairline);
   background: rgba(0, 0, 0, 0.22);
   color: var(--text-primary);
+}
+
+.tool-button.is-armed {
+  border-color: var(--status-danger);
+  color: var(--status-danger);
+  background: rgba(255, 69, 58, 0.16);
 }
 
 .draw-status {

--- a/client/src/design/layout.css
+++ b/client/src/design/layout.css
@@ -479,12 +479,12 @@
   animation: confetti-fall 1.4s ease-in forwards;
 }
 
-.confetti-piece.piece-1 { left: 8%; background: #58efb5; animation-delay: 0.05s; }
-.confetti-piece.piece-2 { left: 22%; background: #ffd166; animation-delay: 0.12s; }
+.confetti-piece.piece-1 { left: 8%; background: #30d158; animation-delay: 0.05s; }
+.confetti-piece.piece-2 { left: 22%; background: #ffd60a; animation-delay: 0.12s; }
 .confetti-piece.piece-3 { left: 38%; background: #63d2ff; animation-delay: 0.18s; }
-.confetti-piece.piece-4 { left: 55%; background: #ff73b7; animation-delay: 0.08s; }
+.confetti-piece.piece-4 { left: 55%; background: #0071e3; animation-delay: 0.08s; }
 .confetti-piece.piece-5 { left: 72%; background: #a8ffe0; animation-delay: 0.22s; }
-.confetti-piece.piece-6 { left: 88%; background: #fff6d7; animation-delay: 0.15s; }
+.confetti-piece.piece-6 { left: 88%; background: #f5f5f7; animation-delay: 0.15s; }
 
 @keyframes confetti-fall {
   to {
@@ -614,12 +614,8 @@
 
 @media (max-height: 780px) {
   .display.phase-final-scores .share-card-button {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    clip: rect(0 0 0 0);
-    overflow: hidden;
+    min-height: 40px;
+    margin-top: var(--space-1);
   }
 
   .display-grid-finalScores .podium-place {

--- a/client/src/drawing.ts
+++ b/client/src/drawing.ts
@@ -1,8 +1,9 @@
-import { Trash2, Undo2, createElement as createIconElement, type IconNode } from 'lucide';
+import { Eraser, Trash2, Undo2, createElement as createIconElement, type IconNode } from 'lucide';
 import { CANVAS_HEIGHT, CANVAS_WIDTH, type DrawingDoc, type Point, type Stroke } from './protocol';
 
 const COLORS = ['#111111', '#ff595e', '#ffca3a', '#34d399', '#1982c4', '#6a4c93', '#f957a8', '#ffffff'];
 const SIZES = [3, 6, 10, 16];
+const ERASER_COLOR = '#ffffff';
 const COLOR_LABELS: Record<string, string> = {
   '#111111': 'black ink',
   '#ff595e': 'red ink',
@@ -26,6 +27,7 @@ const SUMMARY_COLOR_LABELS: Record<string, string> = {
 const MAX_STROKES = 220;
 const MAX_POINTS_PER_STROKE = 180;
 const POINT_DISTANCE_THRESHOLD = 4;
+const CLEAR_ARM_MS = 3000;
 
 export function createEmptyDrawing(): DrawingDoc {
   return {
@@ -70,6 +72,8 @@ export class DrawingPad {
   private readonly sizeButtons = new Map<number, HTMLButtonElement>();
   private readonly undoButton: HTMLButtonElement;
   private readonly clearButton: HTMLButtonElement;
+  private clearArmed = false;
+  private clearArmTimer: number | null = null;
 
   constructor(onChange: () => void, submitSlot?: HTMLElement) {
     this.onChange = onChange;
@@ -101,12 +105,22 @@ export class DrawingPad {
     for (const color of COLORS) {
       const swatch = document.createElement('button');
       swatch.type = 'button';
-      swatch.className = 'swatch';
+      swatch.className = color === ERASER_COLOR ? 'swatch swatch-eraser' : 'swatch';
       swatch.style.background = color;
       swatch.title = `Use ${COLOR_LABELS[color] ?? color}`;
       swatch.setAttribute('aria-label', swatch.title);
+      if (color === ERASER_COLOR) {
+        const eraserIcon = createIconElement(Eraser, {
+          class: 'swatch-eraser-icon',
+          'aria-hidden': 'true',
+          width: 18,
+          height: 18
+        });
+        swatch.appendChild(eraserIcon);
+      }
       swatch.addEventListener('click', () => {
         this.color = color;
+        this.disarmClear();
         this.updateStatus();
       });
       this.colorButtons.set(color, swatch);
@@ -121,6 +135,7 @@ export class DrawingPad {
       sizeButton.title = `Use ${size}px brush`;
       sizeButton.addEventListener('click', () => {
         this.size = size;
+        this.disarmClear();
         this.updateStatus();
       });
       this.sizeButtons.set(size, sizeButton);
@@ -129,6 +144,7 @@ export class DrawingPad {
 
     this.undoButton = iconButton(Undo2, 'Undo last stroke', 'tool-button icon-button');
     this.undoButton.addEventListener('click', () => {
+      this.disarmClear();
       this.drawing.strokes.pop();
       this.limitMessage = '';
       this.redraw();
@@ -139,9 +155,14 @@ export class DrawingPad {
 
     this.clearButton = iconButton(Trash2, 'Clear drawing', 'tool-button icon-button danger');
     this.clearButton.addEventListener('click', () => {
-      if (!this.hasInk() || !window.confirm('Clear your drawing?')) {
+      if (!this.hasInk()) {
         return;
       }
+      if (!this.clearArmed) {
+        this.armClear();
+        return;
+      }
+      this.disarmClear();
       this.drawing.strokes.length = 0;
       this.limitMessage = '';
       this.redraw();
@@ -197,6 +218,7 @@ export class DrawingPad {
         this.updateStatus();
         return;
       }
+      this.disarmClear();
       this.activePointerId = event.pointerId;
       safelySetPointerCapture(this.canvas, event.pointerId);
       const point = this.getPoint(event);
@@ -283,7 +305,43 @@ export class DrawingPad {
       `${this.drawing.strokes.length} ${this.drawing.strokes.length === 1 ? 'stroke' : 'strokes'}`;
     this.undoButton.disabled = !this.hasInk();
     this.clearButton.disabled = !this.hasInk();
+    if (!this.hasInk() && this.clearArmed) {
+      this.disarmClear();
+    }
     this.updateToolState();
+  }
+
+  private armClear(): void {
+    this.clearArmed = true;
+    this.clearButton.classList.add('is-armed');
+    this.clearButton.title = 'Tap again to clear drawing';
+    this.clearButton.setAttribute('aria-label', 'Tap again to clear drawing');
+    this.limitMessage = 'Tap clear again to erase everything.';
+    if (this.clearArmTimer !== null) {
+      window.clearTimeout(this.clearArmTimer);
+    }
+    this.clearArmTimer = window.setTimeout(() => {
+      this.disarmClear();
+      this.updateStatus();
+    }, CLEAR_ARM_MS);
+    this.updateStatus();
+  }
+
+  private disarmClear(): void {
+    if (!this.clearArmed && this.clearArmTimer === null) {
+      return;
+    }
+    this.clearArmed = false;
+    this.clearButton.classList.remove('is-armed');
+    this.clearButton.title = 'Clear drawing';
+    this.clearButton.setAttribute('aria-label', 'Clear drawing');
+    if (this.clearArmTimer !== null) {
+      window.clearTimeout(this.clearArmTimer);
+      this.clearArmTimer = null;
+    }
+    if (this.limitMessage === 'Tap clear again to erase everything.') {
+      this.limitMessage = '';
+    }
   }
 
   private updateToolState(): void {

--- a/client/src/polish.test.ts
+++ b/client/src/polish.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { finalWinnerText, roundOutcomeText } from './polish';
+import {
+  displayLobbyStartNote,
+  finalWinnerText,
+  playerLobbyReadyNote,
+  roundOutcomeText
+} from './polish';
 import type { RoundResult, ScoreEntry } from './protocol';
 
 describe('party polish copy', () => {
@@ -19,6 +24,20 @@ describe('party polish copy', () => {
     expect(finalWinnerText(scores([['Ava', 450], ['Bo', 200]]))).toBe('Ava wins');
     expect(finalWinnerText(scores([['Ava', 300], ['Bo', 300]]))).toBe('Ava and Bo tie');
     expect(finalWinnerText(scores([['Ava', 100], ['Bo', 100], ['Cy', 100]]))).toBe('3 players tie');
+  });
+
+  it('guides hosts toward a fuller party while keeping solo startable', () => {
+    expect(displayLobbyStartNote(0, 1)).toBe('Scan the QR (or type the code). Need 1+ phones.');
+    expect(displayLobbyStartNote(1, 1)).toBe(
+      '1 ready — playable now, best with 3+ for votes and fakes.'
+    );
+    expect(displayLobbyStartNote(2, 1)).toBe(
+      '2 ready — playable now, best with 3+ for votes and fakes.'
+    );
+    expect(displayLobbyStartNote(3, 1)).toBe('3 ready — hit Start when the couch is full.');
+    expect(playerLobbyReadyNote(1, 1)).toBe('Invite 2 more for better voting.');
+    expect(playerLobbyReadyNote(2, 1)).toBe('Invite 1 more for better voting.');
+    expect(playerLobbyReadyNote(3, 1)).toBe('The TV can start the game.');
   });
 });
 

--- a/client/src/polish.ts
+++ b/client/src/polish.ts
@@ -1,9 +1,38 @@
 import type { GamePhase, RoundResult, ScoreEntry } from './protocol';
 
+/** Soft party-size guidance. Server `MIN_PLAYERS` stays 1 for solo/demo. */
+export const RECOMMENDED_PARTY_SIZE = 3;
+
 type RoundOutcomeInput = Pick<
   RoundResult,
   'breakdown' | 'correctVoterNames' | 'nobodyFoundIt' | 'perfectTruth'
 >;
+
+export function displayLobbyStartNote(connectedCount: number, minPlayers: number): string {
+  if (connectedCount < minPlayers) {
+    if (connectedCount === 0) {
+      return `Scan the QR (or type the code). Need ${minPlayers}+ phones.`;
+    }
+    const needed = Math.max(0, minPlayers - connectedCount);
+    return `Need ${needed} more phone${needed === 1 ? '' : 's'} before kickoff.`;
+  }
+  if (connectedCount < RECOMMENDED_PARTY_SIZE) {
+    return `${connectedCount} ready — playable now, best with 3+ for votes and fakes.`;
+  }
+  return `${connectedCount} ready — hit Start when the couch is full.`;
+}
+
+export function playerLobbyReadyNote(connectedCount: number, minPlayers: number): string {
+  const needed = Math.max(0, minPlayers - connectedCount);
+  if (needed > 0) {
+    return `Need ${needed} more ${needed === 1 ? 'player' : 'players'}.`;
+  }
+  if (connectedCount < RECOMMENDED_PARTY_SIZE) {
+    const invite = RECOMMENDED_PARTY_SIZE - connectedCount;
+    return `Invite ${invite} more for better voting.`;
+  }
+  return 'The TV can start the game.';
+}
 
 export function roundOutcomeText(result: RoundOutcomeInput): string {
   if (result.nobodyFoundIt) {

--- a/client/src/share-card.test.ts
+++ b/client/src/share-card.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { drawShareCard, podiumShareLabel } from './share-card';
+
+describe('share card', () => {
+  it('labels download when Web Share is unavailable', () => {
+    expect(podiumShareLabel()).toBe('Download Podium');
+  });
+
+  it('exports a canvas drawer for glass podium cards', () => {
+    expect(typeof drawShareCard).toBe('function');
+  });
+});

--- a/client/src/share-card.ts
+++ b/client/src/share-card.ts
@@ -16,8 +16,19 @@ const FONT_BODY = '"DM Sans", "Segoe UI", "Helvetica Neue", sans-serif';
 export type ShareCardResult = 'shared' | 'downloaded' | 'failed' | 'cancelled';
 
 export function podiumShareLabel(): string {
-  if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
-    return 'Share Podium';
+  if (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.share === 'function' &&
+    typeof navigator.canShare === 'function'
+  ) {
+    try {
+      const probe = new File([new Uint8Array()], 'draw-party-podium.png', { type: 'image/png' });
+      if (navigator.canShare({ files: [probe] })) {
+        return 'Share Podium';
+      }
+    } catch {
+      // Fall through to download label.
+    }
   }
   return 'Download Podium';
 }
@@ -68,8 +79,11 @@ export async function exportShareCard(scores: ScoreEntry[]): Promise<ShareCardRe
     const link = document.createElement('a');
     link.href = url;
     link.download = 'draw-party-podium.png';
+    link.rel = 'noopener';
+    document.body.appendChild(link);
     link.click();
-    URL.revokeObjectURL(url);
+    link.remove();
+    window.setTimeout(() => URL.revokeObjectURL(url), 0);
     return 'downloaded';
   } catch {
     return 'failed';

--- a/client/src/share-card.ts
+++ b/client/src/share-card.ts
@@ -1,7 +1,28 @@
 import { finalWinnerText, podiumTitles } from './polish';
 import type { ScoreEntry } from './protocol';
 
-export async function exportShareCard(scores: ScoreEntry[]): Promise<'ok' | 'failed'> {
+const BG_DEEP = '#05060a';
+const GLOW_A = 'rgba(0, 113, 227, 0.28)';
+const GLOW_B = 'rgba(120, 190, 255, 0.14)';
+const SURFACE = 'rgba(255, 255, 255, 0.10)';
+const BORDER = 'rgba(255, 255, 255, 0.16)';
+const TEXT_PRIMARY = '#f5f5f7';
+const TEXT_SECONDARY = '#a1a1a6';
+const ACCENT = '#0071e3';
+const WARNING = '#ffd60a';
+const FONT_DISPLAY = '"Syne", "Segoe UI Display", "Avenir Next", sans-serif';
+const FONT_BODY = '"DM Sans", "Segoe UI", "Helvetica Neue", sans-serif';
+
+export type ShareCardResult = 'shared' | 'downloaded' | 'failed' | 'cancelled';
+
+export function podiumShareLabel(): string {
+  if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+    return 'Share Podium';
+  }
+  return 'Download Podium';
+}
+
+export async function exportShareCard(scores: ScoreEntry[]): Promise<ShareCardResult> {
   try {
     const canvas = document.createElement('canvas');
     canvas.width = 1080;
@@ -10,32 +31,170 @@ export async function exportShareCard(scores: ScoreEntry[]): Promise<'ok' | 'fai
     if (!ctx) {
       return 'failed';
     }
-    ctx.fillStyle = '#10131f';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = '#fff6d7';
-    ctx.font = 'bold 72px sans-serif';
-    ctx.fillText('Draw Party', 64, 120);
-    ctx.font = 'bold 48px sans-serif';
-    ctx.fillText(finalWinnerText(scores), 64, 220);
 
-    const titles = new Map(podiumTitles(scores).map((entry) => [entry.playerId, entry.title]));
-    const rows = scores.slice(0, 8).map((score, index) => {
-      const title = titles.get(score.playerId);
-      const rank = index < 3 ? ['1st', '2nd', '3rd'][index] : `${index + 1}.`;
-      return `${rank} ${score.name}${title ? ` · ${title}` : ''} ${score.score} pts`;
-    });
-    ctx.font = '36px sans-serif';
-    rows.forEach((row, index) => {
-      ctx.fillText(row, 64, 320 + index * 56);
-    });
+    if (document.fonts?.ready) {
+      await document.fonts.ready;
+    }
+    drawShareCard(ctx, canvas.width, canvas.height, scores);
 
-    const url = canvas.toDataURL('image/png');
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob((result) => resolve(result), 'image/png');
+    });
+    if (!blob) {
+      return 'failed';
+    }
+
+    const file = new File([blob], 'draw-party-podium.png', { type: 'image/png' });
+    if (
+      typeof navigator.share === 'function' &&
+      typeof navigator.canShare === 'function' &&
+      navigator.canShare({ files: [file] })
+    ) {
+      try {
+        await navigator.share({
+          files: [file],
+          title: 'Draw Party',
+          text: finalWinnerText(scores)
+        });
+        return 'shared';
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return 'cancelled';
+        }
+      }
+    }
+
+    const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
     link.download = 'draw-party-podium.png';
     link.click();
-    return 'ok';
+    URL.revokeObjectURL(url);
+    return 'downloaded';
   } catch {
     return 'failed';
+  }
+}
+
+export function drawShareCard(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  scores: ScoreEntry[]
+): void {
+  ctx.fillStyle = BG_DEEP;
+  ctx.fillRect(0, 0, width, height);
+
+  const glowA = ctx.createRadialGradient(220, 180, 20, 220, 180, 420);
+  glowA.addColorStop(0, GLOW_A);
+  glowA.addColorStop(1, 'rgba(0, 113, 227, 0)');
+  ctx.fillStyle = glowA;
+  ctx.fillRect(0, 0, width, height);
+
+  const glowB = ctx.createRadialGradient(860, 1100, 40, 860, 1100, 480);
+  glowB.addColorStop(0, GLOW_B);
+  glowB.addColorStop(1, 'rgba(120, 190, 255, 0)');
+  ctx.fillStyle = glowB;
+  ctx.fillRect(0, 0, width, height);
+
+  roundRect(ctx, 56, 56, width - 112, height - 112, 36);
+  ctx.fillStyle = SURFACE;
+  ctx.fill();
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.fillStyle = ACCENT;
+  ctx.fillRect(88, 108, 72, 8);
+
+  ctx.fillStyle = TEXT_PRIMARY;
+  ctx.font = `700 72px ${FONT_DISPLAY}`;
+  ctx.fillText('Draw Party', 88, 200);
+
+  ctx.fillStyle = TEXT_SECONDARY;
+  ctx.font = `600 28px ${FONT_BODY}`;
+  ctx.fillText('FINAL PODIUM', 88, 260);
+
+  ctx.fillStyle = TEXT_PRIMARY;
+  ctx.font = `700 52px ${FONT_DISPLAY}`;
+  const winnerLine = finalWinnerText(scores);
+  wrapText(ctx, winnerLine, 88, 340, width - 176, 58);
+
+  ctx.strokeStyle = BORDER;
+  ctx.beginPath();
+  ctx.moveTo(88, 430);
+  ctx.lineTo(width - 88, 430);
+  ctx.stroke();
+
+  const titles = new Map(podiumTitles(scores).map((entry) => [entry.playerId, entry.title]));
+  const rows = scores.slice(0, 8);
+  rows.forEach((score, index) => {
+    const y = 510 + index * 88;
+    const rank = index < 3 ? ['1st', '2nd', '3rd'][index] : `${index + 1}.`;
+    const title = titles.get(score.playerId);
+
+    ctx.fillStyle = index === 0 ? ACCENT : TEXT_SECONDARY;
+    ctx.font = `700 28px ${FONT_BODY}`;
+    ctx.fillText(rank, 88, y);
+
+    ctx.fillStyle = TEXT_PRIMARY;
+    ctx.font = `600 36px ${FONT_BODY}`;
+    ctx.fillText(score.name, 180, y);
+
+    if (title) {
+      ctx.fillStyle = WARNING;
+      ctx.font = `700 24px ${FONT_BODY}`;
+      ctx.fillText(title, 180, y + 34);
+    }
+
+    ctx.fillStyle = TEXT_PRIMARY;
+    ctx.font = `700 32px ${FONT_BODY}`;
+    const pts = `${score.score} pts`;
+    const ptsWidth = ctx.measureText(pts).width;
+    ctx.fillText(pts, width - 88 - ptsWidth, y);
+  });
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): void {
+  const r = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + width, y, x + width, y + height, r);
+  ctx.arcTo(x + width, y + height, x, y + height, r);
+  ctx.arcTo(x, y + height, x, y, r);
+  ctx.arcTo(x, y, x + width, y, r);
+  ctx.closePath();
+}
+
+function wrapText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  lineHeight: number
+): void {
+  const words = text.split(' ');
+  let line = '';
+  let cursorY = y;
+  for (const word of words) {
+    const next = line ? `${line} ${word}` : word;
+    if (ctx.measureText(next).width > maxWidth && line) {
+      ctx.fillText(line, x, cursorY);
+      line = word;
+      cursorY += lineHeight;
+    } else {
+      line = next;
+    }
+  }
+  if (line) {
+    ctx.fillText(line, x, cursorY);
   }
 }

--- a/client/src/views/display/DisplayLobby.tsx
+++ b/client/src/views/display/DisplayLobby.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useGame } from '../../app/GameProvider';
+import { displayLobbyStartNote } from '../../polish';
 import {
   defaultRoomSettings,
   isPromptPackId,
@@ -30,7 +31,6 @@ export function DisplayLobby(): React.JSX.Element {
   const joinUrl = `${window.location.origin}/join/${snapshot.roomCode}`;
   const connectedPlayers = activePlayers(snapshot.players);
   const canStart = connectedPlayers.length >= snapshot.minPlayers;
-  const neededPlayers = Math.max(0, snapshot.minPlayers - connectedPlayers.length);
   const settings = snapshot.settings;
 
   return (
@@ -58,11 +58,7 @@ export function DisplayLobby(): React.JSX.Element {
           Start Game
         </Button>
         <p className={canStart ? 'start-note ready' : 'start-note'}>
-          {canStart
-            ? `${connectedPlayers.length} ready — hit Start when the couch is full.`
-            : connectedPlayers.length === 0
-              ? `Scan the QR (or type the code). Need ${snapshot.minPlayers}+ phones.`
-              : `Need ${neededPlayers} more phone${neededPlayers === 1 ? '' : 's'} before kickoff.`}
+          {displayLobbyStartNote(connectedPlayers.length, snapshot.minPlayers)}
         </p>
       </GlassPanel>
 
@@ -176,6 +172,7 @@ function SettingsPanel({
         variant="secondary"
         wide
         className={`sound-toggle ${soundOn ? 'is-selected' : ''}`}
+        aria-pressed={soundOn}
         onClick={onToggleSound}
       >
         {soundOn ? 'Sound On' : 'Sound Off'}

--- a/client/src/views/display/DisplayReveal.tsx
+++ b/client/src/views/display/DisplayReveal.tsx
@@ -63,8 +63,8 @@ export function DisplayVoting(): React.JSX.Element {
         </GlassPanel>
         <GlassPanel className="vote-list panel" tone="soft">
           <div className="panel-title">On the phones</div>
-          {snapshot.votingOptions.map((option, index) => (
-            <div key={option.id} className="vote-option" style={{ ['--row-index' as string]: index }}>
+          {snapshot.votingOptions.map((option) => (
+            <div key={option.id} className="vote-option">
               <span className="vote-answer">{option.text}</span>
             </div>
           ))}

--- a/client/src/views/player/PlayerLobby.tsx
+++ b/client/src/views/player/PlayerLobby.tsx
@@ -1,12 +1,19 @@
+import { useState } from 'react';
 import { useGame } from '../../app/GameProvider';
+import { playerLobbyReadyNote } from '../../polish';
 import { activePlayers } from '../../spectator';
+import { Button } from '../../components/ui/Button';
+import { Field, TextInput } from '../../components/ui/Field';
 import { GlassPanel } from '../../components/ui/GlassPanel';
 import { PlayerList } from '../../components/ui/PlayerList';
 import { Shell } from '../../components/ui/Shell';
 import { SpectatorBanner } from '../../components/ui/SpectatorBanner';
 
 export function PlayerLobby(): React.JSX.Element {
-  const { snapshot, clientId } = useGame();
+  const { snapshot, clientId, setName } = useGame();
+  const [editingName, setEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState('');
+
   if (!snapshot) {
     return (
       <Shell title="Lobby">
@@ -20,16 +27,68 @@ export function PlayerLobby(): React.JSX.Element {
   const self = snapshot.players.find((player) => player.id === clientId);
   const spectating = Boolean(self?.spectator);
   const ready = neededPlayers === 0;
+  const displayName = self?.name ?? 'Player';
+
+  const startRename = () => {
+    setNameDraft(displayName);
+    setEditingName(true);
+  };
+
+  const cancelRename = () => {
+    setEditingName(false);
+    setNameDraft('');
+  };
+
+  const saveRename = () => {
+    const next = nameDraft.trim() || 'Player';
+    setName(next);
+    setEditingName(false);
+    setNameDraft('');
+  };
 
   return (
     <Shell title="Lobby">
       <div className="player-stack lobby-player-stack">
         <GlassPanel className={`player-lobby-card ${ready && !spectating ? 'is-ready' : ''}`}>
           {spectating ? <SpectatorBanner /> : null}
-          <p className="eyebrow">{self ? `${self.name}, you're in` : "You're in"}</p>
+          <p className="eyebrow">{self ? `${displayName}, you're in` : "You're in"}</p>
           <h2>
             {spectating ? 'Watching the lobby' : ready ? 'Party is ready' : 'Waiting for players'}
           </h2>
+          {!editingName ? (
+            <div className="lobby-name-row">
+              <span className="muted">Playing as {displayName}</span>
+              <Button variant="ghost" className="tool-button lobby-rename-button" onClick={startRename}>
+                Edit name
+              </Button>
+            </div>
+          ) : (
+            <form
+              className="lobby-rename-form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                saveRename();
+              }}
+            >
+              <Field label="Your name">
+                <TextInput
+                  value={nameDraft}
+                  maxLength={24}
+                  autoComplete="nickname"
+                  autoFocus
+                  onChange={(event) => setNameDraft(event.target.value)}
+                />
+              </Field>
+              <div className="lobby-rename-actions">
+                <Button type="submit" wide>
+                  Save name
+                </Button>
+                <Button type="button" variant="secondary" wide onClick={cancelRename}>
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          )}
           <div className="player-room-chip">
             <span>Room</span>
             <strong className="mini-room-code">{snapshot.roomCode}</strong>
@@ -41,9 +100,7 @@ export function PlayerLobby(): React.JSX.Element {
             <span>
               {spectating
                 ? 'You join as a player on the next drawing round.'
-                : ready
-                  ? 'The TV can start the game.'
-                  : `Need ${neededPlayers} more ${neededPlayers === 1 ? 'player' : 'players'}.`}
+                : playerLobbyReadyNote(connectedPlayers.length, snapshot.minPlayers)}
             </span>
           </div>
           <p className="muted">

--- a/client/src/views/player/PlayerPlay.tsx
+++ b/client/src/views/player/PlayerPlay.tsx
@@ -107,7 +107,7 @@ export function PlayerVoting(): React.JSX.Element {
           <div className="success-box">You’re the artist. Watch who takes the bait.</div>
         ) : (
           <div className="vote-list compact player-vote-list">
-            {snapshot.votingOptions.map((option, index) => {
+            {snapshot.votingOptions.map((option) => {
               const ownGuess = option.authorPlayerId === clientId;
               const selected = selectedVoteForTurn?.optionId === option.id;
               const waitingForVoteAck = Boolean(selectedVoteForTurn);
@@ -118,7 +118,6 @@ export function PlayerVoting(): React.JSX.Element {
                   type="button"
                   className={`${disabled ? 'vote-option disabled' : 'vote-option'}${selected ? ' is-selected' : ''}`}
                   disabled={disabled}
-                  style={{ ['--row-index' as string]: index }}
                   onClick={() => {
                     setSelectedVote({ turnToken, optionId: option.id });
                     send({ type: 'submitVote', turnToken, optionId: option.id });

--- a/client/src/views/player/PlayerResults.tsx
+++ b/client/src/views/player/PlayerResults.tsx
@@ -30,12 +30,17 @@ export function PlayerResults(): React.JSX.Element {
 }
 
 export function PlayerFinal(): React.JSX.Element {
-  const { snapshot } = useGame();
+  const { snapshot, setErrorMessage } = useGame();
   const scores = snapshot?.finalScores ?? [];
 
   return (
     <Shell title="Final Scores">
-      <ScoresPanel scores={scores} podium role="player" />
+      <ScoresPanel
+        scores={scores}
+        podium
+        role="player"
+        onShareFailed={() => setErrorMessage('Could not export the podium card.')}
+      />
     </Shell>
   );
 }

--- a/client/src/views/player/SpectatorWatch.tsx
+++ b/client/src/views/player/SpectatorWatch.tsx
@@ -102,12 +102,8 @@ export function SpectatorVoting(): React.JSX.Element {
         <p className="action-hint">Watch the vote on the TV.</p>
         <DrawingCanvas drawing={snapshot.currentDrawing} className="reveal-canvas phone-canvas" />
         <div className="vote-list compact player-vote-list">
-          {snapshot.votingOptions.map((option, index) => (
-            <div
-              key={option.id}
-              className="vote-option disabled"
-              style={{ ['--row-index' as string]: index }}
-            >
+          {snapshot.votingOptions.map((option) => (
+            <div key={option.id} className="vote-option disabled">
               <span className="vote-answer">{option.text}</span>
             </div>
           ))}

--- a/docs/design.md
+++ b/docs/design.md
@@ -114,8 +114,8 @@ Animate only `transform` and `opacity`. Honor `prefers-reduced-motion: reduce` b
 | `GlassPanel` | Frosted content surface |
 | `Button` | Pill CTA / glass secondary / quiet tool |
 | `Field` | Glass input + label |
-| Status chips | Markup uses `.pill` (`.badge` is an unused CSS alias) |
-| Shell brand | Wordmark via Shell / `.brand` (`.brand-mark` CSS exists but is unused) |
+| Status chips | `.pill` status / meta chips |
+| Shell brand | Wordmark via Shell / `.brand` |
 | `PlayerList` | Couch-readable roster rows (`.player-row`) |
 | `Deadline` | Large countdown (`#deadline-text`) |
 | `QrCode` | Join QR |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -55,7 +55,7 @@ Important fields:
 |------|---------|
 | `createRoom` | Display creates a room |
 | `joinRoom` | Player joins with `roomCode` + `name` |
-| `setName` | Rename player (no phase gate; current client sets name via `joinRoom` only) |
+| `setName` | Rename player (no server phase gate; client exposes rename in lobby) |
 | `updateRoomSettings` | Display updates timers/rounds/pack (lobby only) |
 | `startGame` | Display starts the game, Continues after results, or Play Again from final scores |
 | `submitDrawing` | `turnToken` + `drawing` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Client polish pass for party cohesion:

- Restyle the podium share card to the dark glass / Syne–DM Sans system, with Web Share + download fallback, visible on short TVs, and available on phone final scores
- Soft “best with 3+” lobby guidance while keeping `MIN_PLAYERS = 1`
- In-lobby rename via existing `setName` protocol (reconnect-safe)
- Drawing pad: larger touch targets, explicit eraser swatch, tap-again clear
- Cohesion cleanup: confetti tokens, unused `.badge`/`.brand-mark`, leftover `--row-index`, sound `aria-pressed`

## Review fix-up
- Keep `pendingJoin` name in sync on rename so reconnect `joinRoom` cannot overwrite it
- Only label the button “Share Podium” when `canShare({ files })` succeeds

## Validation
- `npm --prefix client run typecheck` — pass
- `npm --prefix client test -- --run` — pass (21 tests)
- `npm --prefix client run e2e -- e2e/polish.e2e.ts` — pass (10 tests, pre-fixup)
- CI validate on PR — waiting / green before merge

## Out of scope
Server min-player raise, new prompt packs, true vector eraser compositing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dfdcce0-4628-45df-997a-443d69b18cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dfdcce0-4628-45df-997a-443d69b18cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

