### PR TITLE
fix(client): harden TV lobby layout and add pre-prod gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,10 @@
 - [ ] WebSocket / reconnect / health / static: Rust tests including `main.rs` (if touched)
 - [ ] Client logic / protocol: `npm --prefix client test -- --run` + typecheck (if touched)
 - [ ] UI / layout / touch: relevant Playwright e2e, including mobile phone contexts (if touched)
+- [ ] TV / display layout: `npm run e2e:tv` (if lobby/display CSS touched); optional `npm run review:tv` gallery glance
 - [ ] Protocol changes updated both `server/src/protocol.rs` and `client/src/protocol.ts` (+ `docs/protocol.md`)
 - [ ] Docs updated when architecture, design, or deploy behavior changed
 
 ## Notes
 
-<!-- Screenshots, deploy smoke, or follow-ups -->
+<!-- Screenshots, deploy smoke, or follow-ups. For TV UI: attach `client/artifacts/tv-review/` shots or the CI `tv-layout-review` artifact. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,14 @@ jobs:
 
       - name: Run Playwright e2e
         run: npm run e2e
+        env:
+          TV_REVIEW: '1'
+
+      - name: Upload TV layout review gallery
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tv-layout-review
+          path: client/artifacts/tv-review/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ client/node_modules/
 client/dist/
 client/test-results/
 client/playwright-report/
+client/artifacts/
 .DS_Store
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Draw Party is an open-source Drawful-style party game for a TV/display browser a
 - `client/src/hooks/useRevealStage.ts`: results reveal staging timing (hold → tally → correct → deltas → complete).
 - `client/src/polish.ts`: outcome copy, podium titles, and action hints.
 - `client/src/design/`: CSS tokens and glass styles (see `docs/design.md`).
-- `client/e2e/`: Playwright coverage for full rounds, device compatibility, polish, and PWA cache behavior.
+- `client/e2e/`: Playwright coverage for full rounds, device compatibility, TV layout gates, polish, and PWA cache behavior.
 
 ## Game Flow
 
@@ -83,6 +83,7 @@ Narrow change tips (see contributing for the full matrix):
 - WebSocket / reconnect / health / static: `cargo test` including `main.rs` tests
 - Client logic / protocol: `npm --prefix client test -- --run` + typecheck
 - UI / layout / touch: relevant Playwright e2e (include mobile phone contexts)
+- TV / display layout: `npm run e2e:tv` (+ `npm run review:tv` gallery when shipping lobby/display CSS)
 - Release verification: `/api/health` commit check, then `E2E_BASE_URL=<url> npm run e2e` when practical
 
 ## Development Guidance

--- a/client/e2e/device-compat.e2e.ts
+++ b/client/e2e/device-compat.e2e.ts
@@ -1,4 +1,10 @@
 import { expect, test, type Browser, type BrowserContext, type Page, type TestInfo } from '@playwright/test';
+import {
+  assertDisplayLobbyLayout,
+  expectNoHorizontalOverflow,
+  expectNoVerticalOverflow,
+  TV_VIEWPORTS
+} from './tv-layout';
 
 type Viewport = {
   width: number;
@@ -13,14 +19,6 @@ type PlayerTarget = {
   minCanvasWidth: number;
   minBackingRatio?: number;
 };
-
-const TV_TARGETS: Array<{ name: string; viewport: Viewport }> = [
-  { name: 'tvbro-720p', viewport: { width: 1280, height: 720 } },
-  { name: 'tvbro-768p', viewport: { width: 1366, height: 768 } },
-  { name: 'full-hd-tv', viewport: { width: 1920, height: 1080 } },
-  { name: 'qhd-tv', viewport: { width: 2560, height: 1440 } },
-  { name: 'uhd-4k-tv', viewport: { width: 3840, height: 2160 } }
-];
 
 const PLAYER_TARGETS: PlayerTarget[] = [
   {
@@ -102,23 +100,12 @@ const PLAYER_TARGETS: PlayerTarget[] = [
 test('TV Bro style lobby fits from 720p through 4K without page scroll', async ({ baseURL, browser }, testInfo) => {
   const appUrl = makeAppUrl(baseURL);
 
-  for (const target of TV_TARGETS) {
-    const context = await browser.newContext({ viewport: target.viewport });
+  for (const target of TV_VIEWPORTS) {
+    const context = await browser.newContext({ viewport: { width: target.width, height: target.height } });
     try {
       const page = await context.newPage();
       await page.goto(appUrl('/'));
-      await expect(page.locator('.room-code')).toHaveText(/[A-Z]{4}/);
-      await expect(page.locator('.qr')).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Start Game' })).toBeVisible();
-      await expectNoHorizontalOverflow(page);
-      await expectNoVerticalOverflow(page);
-
-      const metrics = await tvMetrics(page);
-      expect(metrics.qr.bottom).toBeLessThanOrEqual(target.viewport.height + 4);
-      expect(metrics.start.bottom).toBeLessThanOrEqual(target.viewport.height + 4);
-      expect(metrics.roomCode.height).toBeLessThan(target.viewport.height * 0.18);
-      expect(metrics.qr.width).toBeGreaterThanOrEqual(target.viewport.width >= 1800 ? 250 : 180);
-
+      await assertDisplayLobbyLayout(page, target);
       await page.screenshot({ path: testInfo.outputPath(`${target.name}-lobby.png`), fullPage: false });
     } finally {
       await context.close();
@@ -297,43 +284,6 @@ async function startSoloDrawing(
   await tv.getByRole('button', { name: 'Start Game' }).click();
   await expect(player.locator('canvas.draw-canvas')).toBeVisible();
   return { player, tv };
-}
-
-async function expectNoHorizontalOverflow(page: Page): Promise<void> {
-  await expect
-    .poll(async () =>
-      page.evaluate(() => Math.ceil(document.documentElement.scrollWidth) <= Math.ceil(window.innerWidth) + 1)
-    )
-    .toBe(true);
-}
-
-async function expectNoVerticalOverflow(page: Page): Promise<void> {
-  await expect
-    .poll(async () =>
-      page.evaluate(() => Math.ceil(document.documentElement.scrollHeight) <= Math.ceil(window.innerHeight) + 4)
-    )
-    .toBe(true);
-}
-
-async function tvMetrics(page: Page): Promise<{
-  qr: DOMRect;
-  roomCode: DOMRect;
-  start: DOMRect;
-}> {
-  return page.evaluate(() => {
-    const rect = (selector: string): DOMRect => {
-      const element = document.querySelector(selector);
-      if (!element) {
-        throw new Error(`Missing ${selector}`);
-      }
-      return element.getBoundingClientRect().toJSON();
-    };
-    return {
-      qr: rect('.qr'),
-      roomCode: rect('.room-code'),
-      start: rect('.start-button')
-    };
-  });
 }
 
 async function playerMetrics(page: Page): Promise<{

--- a/client/e2e/tv-layout.e2e.ts
+++ b/client/e2e/tv-layout.e2e.ts
@@ -1,0 +1,125 @@
+import { expect, test, type BrowserContext } from '@playwright/test';
+import { createPlayers, drawStroke, makeAppUrl } from './helpers';
+import {
+  assertDisplayLobbyLayout,
+  assertDisplayPhaseFits,
+  TV_REVIEW_VIEWPORTS,
+  TV_VIEWPORTS,
+  writeTvReviewIndex,
+  writeTvReviewShot,
+  type TvViewport
+} from './tv-layout';
+
+const reviewEntries: Array<{ title: string; file: string }> = [];
+
+test.afterAll(async () => {
+  await writeTvReviewIndex(reviewEntries);
+});
+
+test('TV layout gate: empty lobby stays readable from 720p through 4K', async ({ baseURL, browser }, testInfo) => {
+  const appUrl = makeAppUrl(baseURL);
+
+  for (const target of TV_VIEWPORTS) {
+    const context = await browser.newContext({ viewport: { width: target.width, height: target.height } });
+    try {
+      const page = await context.newPage();
+      await page.goto(appUrl('/'));
+      await assertDisplayLobbyLayout(page, target);
+
+      const shotName = `${target.name}-empty-lobby.png`;
+      await page.screenshot({ path: testInfo.outputPath(shotName), fullPage: false });
+      const reviewPath = await writeTvReviewShot(page, shotName);
+      if (reviewPath) {
+        reviewEntries.push({ title: `${target.name} · empty lobby`, file: shotName });
+      }
+    } finally {
+      await context.close();
+    }
+  }
+});
+
+test('TV layout gate: populated lobby keeps roster rows stacked', async ({ baseURL, browser }, testInfo) => {
+  const appUrl = makeAppUrl(baseURL);
+  const targets: TvViewport[] = TV_REVIEW_VIEWPORTS;
+
+  for (const target of targets) {
+    const contexts: BrowserContext[] = [];
+    try {
+      const tvContext = await browser.newContext({ viewport: { width: target.width, height: target.height } });
+      contexts.push(tvContext);
+      const tv = await tvContext.newPage();
+      await tv.goto(appUrl('/'));
+      await expect(tv.locator('.room-code')).toHaveText(/[A-Z]{4}/);
+      const roomCode = (await tv.locator('.room-code').innerText()).trim();
+
+      await createPlayers(browser, contexts, appUrl, roomCode, ['Ava', 'Bo', 'Cy']);
+      await expect(tv.getByRole('button', { name: 'Start Game' })).toBeEnabled();
+      await assertDisplayLobbyLayout(tv, target);
+
+      const shotName = `${target.name}-populated-lobby.png`;
+      await tv.screenshot({ path: testInfo.outputPath(shotName), fullPage: false });
+      const reviewPath = await writeTvReviewShot(tv, shotName);
+      if (reviewPath) {
+        reviewEntries.push({ title: `${target.name} · populated lobby`, file: shotName });
+      }
+    } finally {
+      await Promise.all(contexts.map((context) => context.close()));
+    }
+  }
+});
+
+test('TV layout gate: drawing and guessing phases fit key living-room sizes', async ({ baseURL, browser }, testInfo) => {
+  const appUrl = makeAppUrl(baseURL);
+
+  for (const target of TV_REVIEW_VIEWPORTS) {
+    const contexts: BrowserContext[] = [];
+    try {
+      const tvContext = await browser.newContext({ viewport: { width: target.width, height: target.height } });
+      contexts.push(tvContext);
+      const tv = await tvContext.newPage();
+      await tv.goto(appUrl('/'));
+      await expect(tv.locator('.room-code')).toHaveText(/[A-Z]{4}/);
+      const roomCode = (await tv.locator('.room-code').innerText()).trim();
+
+      const players = await createPlayers(browser, contexts, appUrl, roomCode, ['FitA', 'FitB']);
+      await tv.getByRole('button', { name: 'Start Game' }).click();
+
+      for (const player of players) {
+        await expect(player.locator('canvas.draw-canvas')).toBeVisible({ timeout: 15_000 });
+      }
+      await assertDisplayPhaseFits(tv, target);
+      await expect(tv.locator('.progress-panel')).toBeVisible();
+
+      const drawingShot = `${target.name}-drawing.png`;
+      await tv.screenshot({ path: testInfo.outputPath(drawingShot), fullPage: false });
+      if (await writeTvReviewShot(tv, drawingShot)) {
+        reviewEntries.push({ title: `${target.name} · drawing`, file: drawingShot });
+      }
+
+      for (const player of players) {
+        await drawStroke(player);
+        await expect(player.getByRole('button', { name: 'Submit Drawing' })).toBeEnabled();
+        await player.getByRole('button', { name: 'Submit Drawing' }).click();
+      }
+
+      await expect(tv.getByText('What did they draw?')).toBeVisible({ timeout: 20_000 });
+      await assertDisplayPhaseFits(tv, target);
+      const revealBottom = await tv.evaluate(() => {
+        const canvas = document.querySelector('.reveal-canvas');
+        if (!canvas) {
+          throw new Error('Missing reveal canvas');
+        }
+        return canvas.getBoundingClientRect().bottom;
+      });
+      expect(revealBottom).toBeLessThanOrEqual(target.height + 4);
+
+      const guessingShot = `${target.name}-guessing.png`;
+      await tv.screenshot({ path: testInfo.outputPath(guessingShot), fullPage: false });
+      if (await writeTvReviewShot(tv, guessingShot)) {
+        reviewEntries.push({ title: `${target.name} · guessing`, file: guessingShot });
+      }
+    } finally {
+      await Promise.all(contexts.map((context) => context.close()));
+    }
+  }
+});

--- a/client/e2e/tv-layout.ts
+++ b/client/e2e/tv-layout.ts
@@ -1,0 +1,229 @@
+import { expect, type Page } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type TvViewport = {
+  name: string;
+  width: number;
+  height: number;
+};
+
+/** Living-room TV Bro / smart-TV CSS viewports we gate before production. */
+export const TV_VIEWPORTS: TvViewport[] = [
+  { name: 'tvbro-720p', width: 1280, height: 720 },
+  { name: 'tvbro-768p', width: 1366, height: 768 },
+  { name: 'full-hd-tv', width: 1920, height: 1080 },
+  { name: 'qhd-tv', width: 2560, height: 1440 },
+  { name: 'uhd-4k-tv', width: 3840, height: 2160 }
+];
+
+/** Subset used for heavier mid-game layout checks. */
+export const TV_REVIEW_VIEWPORTS: TvViewport[] = [
+  { name: 'tvbro-720p', width: 1280, height: 720 },
+  { name: 'full-hd-tv', width: 1920, height: 1080 },
+  { name: 'uhd-4k-tv', width: 3840, height: 2160 }
+];
+
+export type Box = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+};
+
+const clientDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+export const TV_REVIEW_DIR = join(clientDir, 'artifacts', 'tv-review');
+
+export function boxesOverlap(a: Box, b: Box, slack = 1): boolean {
+  return !(
+    a.bottom <= b.top + slack ||
+    b.bottom <= a.top + slack ||
+    a.right <= b.left + slack ||
+    b.right <= a.left + slack
+  );
+}
+
+export async function rectOf(page: Page, selector: string): Promise<Box> {
+  return page.evaluate((sel) => {
+    const element = document.querySelector(sel);
+    if (!element) {
+      throw new Error(`Missing ${sel}`);
+    }
+    return element.getBoundingClientRect().toJSON();
+  }, selector);
+}
+
+export async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  await expect
+    .poll(async () =>
+      page.evaluate(() => Math.ceil(document.documentElement.scrollWidth) <= Math.ceil(window.innerWidth) + 1)
+    )
+    .toBe(true);
+}
+
+export async function expectNoVerticalOverflow(page: Page): Promise<void> {
+  await expect
+    .poll(async () =>
+      page.evaluate(() => Math.ceil(document.documentElement.scrollHeight) <= Math.ceil(window.innerHeight) + 4)
+    )
+    .toBe(true);
+}
+
+export type LobbyLayoutMetrics = {
+  emptyState: Box | null;
+  hero: Box;
+  playerRows: Box[];
+  playersCount: Box;
+  qr: Box;
+  roomCode: Box;
+  roomPanel: Box;
+  start: Box;
+};
+
+export async function readLobbyLayout(page: Page): Promise<LobbyLayoutMetrics> {
+  return page.evaluate(() => {
+    const rect = (selector: string): Box => {
+      const element = document.querySelector(selector);
+      if (!element) {
+        throw new Error(`Missing ${selector}`);
+      }
+      return element.getBoundingClientRect().toJSON();
+    };
+    const optionalRect = (selector: string): Box | null => {
+      const element = document.querySelector(selector);
+      return element ? element.getBoundingClientRect().toJSON() : null;
+    };
+    return {
+      emptyState: optionalRect('.players-panel .empty-state'),
+      hero: rect('.room-hero-copy h2'),
+      playerRows: Array.from(document.querySelectorAll('.players-panel .player-row')).map((row) =>
+        row.getBoundingClientRect().toJSON()
+      ),
+      playersCount: rect('.players-panel .players-count'),
+      qr: rect('.qr'),
+      roomCode: rect('.room-code'),
+      roomPanel: rect('.room-panel'),
+      start: rect('.start-button')
+    };
+  });
+}
+
+/** Geometric invariants that failed on 4K TV Bro (clipped hero, stacked player copy). */
+export async function assertDisplayLobbyLayout(
+  page: Page,
+  viewport: Pick<TvViewport, 'width' | 'height'>
+): Promise<LobbyLayoutMetrics> {
+  await expect(page.locator('.room-code')).toHaveText(/[A-Z]{4}/);
+  await expect(page.locator('.qr')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Start Game' })).toBeVisible();
+  await expect(page.getByText('Everybody draws. Everybody lies.')).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+  await expectNoVerticalOverflow(page);
+
+  const metrics = await readLobbyLayout(page);
+  expect(metrics.qr.bottom).toBeLessThanOrEqual(viewport.height + 4);
+  expect(metrics.start.bottom).toBeLessThanOrEqual(viewport.height + 4);
+  expect(metrics.roomCode.height).toBeLessThan(viewport.height * 0.18);
+  expect(metrics.qr.width).toBeGreaterThanOrEqual(viewport.width >= 1800 ? 250 : 180);
+
+  // Hero must stay inside the room panel (no top-edge clip).
+  expect(metrics.hero.top).toBeGreaterThanOrEqual(metrics.roomPanel.top + 4);
+  expect(metrics.hero.bottom).toBeLessThanOrEqual(metrics.roomCode.top + 2);
+
+  // Players meta must stack cleanly — never paint on the same box.
+  if (metrics.emptyState) {
+    expect(metrics.playersCount.bottom).toBeLessThanOrEqual(metrics.emptyState.top + 2);
+    expect(metrics.emptyState.top - metrics.playersCount.top).toBeGreaterThan(10);
+    expect(boxesOverlap(metrics.playersCount, metrics.emptyState)).toBe(false);
+  } else {
+    expect(metrics.playerRows.length).toBeGreaterThan(0);
+    expect(metrics.playersCount.bottom).toBeLessThanOrEqual(metrics.playerRows[0].top + 2);
+    for (let index = 0; index < metrics.playerRows.length; index += 1) {
+      const row = metrics.playerRows[index];
+      expect(boxesOverlap(metrics.playersCount, row)).toBe(false);
+      if (index > 0) {
+        expect(boxesOverlap(metrics.playerRows[index - 1], row)).toBe(false);
+        expect(row.top).toBeGreaterThanOrEqual(metrics.playerRows[index - 1].bottom - 1);
+      }
+    }
+  }
+
+  return metrics;
+}
+
+export async function assertDisplayPhaseFits(page: Page, viewport: Pick<TvViewport, 'width' | 'height'>): Promise<void> {
+  await expectNoHorizontalOverflow(page);
+  await expectNoVerticalOverflow(page);
+  const shellBottom = await page.evaluate(() => {
+    const shell = document.querySelector('.app-shell.display');
+    if (!shell) {
+      throw new Error('Missing display shell');
+    }
+    return shell.getBoundingClientRect().bottom;
+  });
+  expect(shellBottom).toBeLessThanOrEqual(viewport.height + 4);
+}
+
+export function shouldWriteTvReviewGallery(): boolean {
+  return process.env.TV_REVIEW === '1' || process.env.CI === 'true';
+}
+
+export async function writeTvReviewShot(page: Page, filename: string): Promise<string | null> {
+  if (!shouldWriteTvReviewGallery()) {
+    return null;
+  }
+  await mkdir(TV_REVIEW_DIR, { recursive: true });
+  const path = join(TV_REVIEW_DIR, filename);
+  await page.screenshot({ path, fullPage: false });
+  return path;
+}
+
+export async function writeTvReviewIndex(entries: Array<{ title: string; file: string }>): Promise<void> {
+  if (!shouldWriteTvReviewGallery() || entries.length === 0) {
+    return;
+  }
+  await mkdir(TV_REVIEW_DIR, { recursive: true });
+  const cards = entries
+    .map(
+      (entry) => `    <figure>
+      <figcaption>${escapeHtml(entry.title)}</figcaption>
+      <img src="./${escapeHtml(entry.file)}" alt="${escapeHtml(entry.title)}" />
+    </figure>`
+    )
+    .join('\n');
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Draw Party TV review</title>
+  <style>
+    :root { color-scheme: dark; font-family: "DM Sans", system-ui, sans-serif; }
+    body { margin: 0; padding: 24px; background: #05060a; color: #f5f5f7; }
+    h1 { margin: 0 0 8px; font-size: 1.5rem; }
+    p { margin: 0 0 24px; color: #a1a1a6; }
+    main { display: grid; gap: 24px; }
+    figure { margin: 0; border: 1px solid rgba(255,255,255,0.16); border-radius: 16px; overflow: hidden; background: #0c0e16; }
+    figcaption { padding: 12px 16px; font-weight: 600; border-bottom: 1px solid rgba(255,255,255,0.08); }
+    img { display: block; width: 100%; height: auto; background: #000; }
+  </style>
+</head>
+<body>
+  <h1>Draw Party TV layout review</h1>
+  <p>Geometric e2e already asserted non-clip / non-overlap. Glance these shots before shipping living-room UI.</p>
+  <main>
+${cards}
+  </main>
+</body>
+</html>
+`;
+  await writeFile(join(TV_REVIEW_DIR, 'index.html'), html, 'utf8');
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/client/e2e/tv-layout.ts
+++ b/client/e2e/tv-layout.ts
@@ -48,16 +48,6 @@ export function boxesOverlap(a: Box, b: Box, slack = 1): boolean {
   );
 }
 
-export async function rectOf(page: Page, selector: string): Promise<Box> {
-  return page.evaluate((sel) => {
-    const element = document.querySelector(sel);
-    if (!element) {
-      throw new Error(`Missing ${sel}`);
-    }
-    return element.getBoundingClientRect().toJSON();
-  }, selector);
-}
-
 export async function expectNoHorizontalOverflow(page: Page): Promise<void> {
   await expect
     .poll(async () =>

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,8 @@
     "build": "tsc -p tsconfig.json && vite build",
     "e2e": "playwright test -c e2e/playwright.config.ts",
     "e2e:install": "playwright install chromium",
+    "e2e:tv": "playwright test -c e2e/playwright.config.ts --grep \"TV layout gate\"",
+    "review:tv": "TV_REVIEW=1 playwright test -c e2e/playwright.config.ts --grep \"TV layout gate\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest"
   },

--- a/client/src/components/ui/PlayerList.tsx
+++ b/client/src/components/ui/PlayerList.tsx
@@ -7,7 +7,11 @@ interface PlayerListProps {
 
 export function PlayerList({ players, showScores = false }: PlayerListProps): React.JSX.Element {
   if (players.length === 0) {
-    return <div className="empty-state">Waiting for phones to join.</div>;
+    return (
+      <div className="player-list player-list--empty">
+        <div className="empty-state">Waiting for phones to join.</div>
+      </div>
+    );
   }
 
   return (

--- a/client/src/design/components.css
+++ b/client/src/design/components.css
@@ -12,6 +12,21 @@
   min-width: 0;
 }
 
+/* TV Bro / older WebViews: opaque fill so frosted glass never paints twice. */
+.app-shell.display .glass-panel {
+  background: rgba(12, 14, 22, 0.88);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.app-shell.display .glass-panel--soft {
+  background: rgba(12, 14, 22, 0.78);
+}
+
+.app-shell.display .glass-panel--strong {
+  background: rgba(16, 18, 28, 0.92);
+}
+
 .glass-panel--soft {
   background: var(--surface-glass-soft);
 }
@@ -205,12 +220,17 @@
   text-align: center;
 }
 
+.room-hero-copy {
+  position: relative;
+  z-index: 1;
+}
+
 .room-hero-copy h2 {
   margin: 0;
   font-family: var(--font-display);
-  font-size: clamp(1.75rem, 3.2vw, 2.8rem);
+  font-size: clamp(1.6rem, 2.8vw, 2.5rem);
   letter-spacing: -0.03em;
-  line-height: 1.1;
+  line-height: 1.15;
 }
 
 .room-code-wrap {
@@ -228,10 +248,10 @@
 
 .room-code {
   font-family: var(--font-display);
-  font-size: clamp(2.6rem, 6vw, 5.2rem);
+  font-size: clamp(2.4rem, 5.2vw, 4.8rem);
   font-weight: 700;
   letter-spacing: 0.08em;
-  line-height: 0.9;
+  line-height: 1;
 }
 
 .qr-stage {
@@ -479,6 +499,11 @@
 .empty-state {
   color: var(--text-tertiary);
   padding: var(--space-4) 0;
+  line-height: 1.4;
+}
+
+.player-list--empty .empty-state {
+  padding: var(--space-2) 0;
 }
 
 .join-card h2,

--- a/client/src/design/components.css
+++ b/client/src/design/components.css
@@ -14,17 +14,17 @@
 
 /* TV Bro / older WebViews: opaque fill so frosted glass never paints twice. */
 .app-shell.display .glass-panel {
-  background: rgba(12, 14, 22, 0.88);
+  background: var(--surface-tv);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
 }
 
 .app-shell.display .glass-panel--soft {
-  background: rgba(12, 14, 22, 0.78);
+  background: var(--surface-tv-soft);
 }
 
 .app-shell.display .glass-panel--strong {
-  background: rgba(16, 18, 28, 0.92);
+  background: var(--surface-tv-strong);
 }
 
 .glass-panel--soft {

--- a/client/src/design/layout.css
+++ b/client/src/design/layout.css
@@ -30,27 +30,52 @@
 .display-grid-lobby .lobby-side {
   min-height: 0;
   overflow: hidden;
-  grid-template-rows: minmax(142px, 0.58fr) auto;
+  /* Players flexes; settings sizes to content so the roster never collapses. */
+  grid-template-rows: minmax(160px, 1fr) auto;
 }
 
 .display-grid-lobby .players-panel {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
   min-height: 0;
-  padding: 22px;
+  overflow: hidden;
+  padding: clamp(16px, 1.6vw, 24px);
+}
+
+.display-grid-lobby .players-panel .panel-title,
+.display-grid-lobby .players-panel .players-count {
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+.display-grid-lobby .players-panel .players-count {
+  line-height: 1.35;
 }
 
 .display-grid-lobby .players-panel .player-list {
-  min-height: 0;
+  flex: 1 1 auto;
+  min-height: 3.5rem;
   overflow: auto;
   scrollbar-width: thin;
 }
 
+.display-grid-lobby .players-panel .player-list--empty {
+  display: flex;
+  align-items: center;
+}
+
+.display-grid-lobby .players-panel .empty-state {
+  padding: var(--space-2) 0;
+  margin: 0;
+  line-height: 1.4;
+}
+
 .display-grid-lobby .settings-panel {
   display: grid;
-  grid-template-columns: minmax(112px, 0.52fr) minmax(0, 1fr);
-  gap: 4px 10px;
-  padding: 14px 18px;
+  grid-template-columns: minmax(128px, 0.55fr) minmax(0, 1fr);
+  gap: 8px 12px;
+  padding: 16px 18px;
   align-content: start;
 }
 
@@ -111,25 +136,39 @@
 .room-panel {
   min-height: 0;
   height: 100%;
-  align-content: center;
-  gap: 9px;
+  /* Start-aligned so oversized QR/code never clips the hero into the top edge. */
+  align-content: start;
+  justify-content: center;
+  gap: clamp(8px, 1.2vh, 14px);
   padding: clamp(16px, 2vw, 28px);
+  overflow: hidden;
+}
+
+.room-panel .room-hero-copy {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.room-panel .room-hero-copy h2 {
+  text-wrap: balance;
 }
 
 .room-code {
-  font-size: clamp(2.6rem, 6vw, 5.2rem);
-  line-height: 0.9;
+  font-size: clamp(2.4rem, 5.2vw, 4.8rem);
+  line-height: 1;
 }
 
 .qr-stage {
   width: auto;
   padding: 8px;
   margin: 0 auto;
+  flex: 0 1 auto;
+  min-height: 0;
 }
 
 .qr {
-  width: min(220px, 28svh, 18vw) !important;
-  height: min(220px, 28svh, 18vw) !important;
+  width: min(220px, 26svh, 18vw) !important;
+  height: min(220px, 26svh, 18vw) !important;
 }
 
 .brand {
@@ -627,25 +666,47 @@
   }
 }
 
+/* Large TVs: scale with viewport height so hero + QR + CTA stay in one frame. */
 @media (min-width: 1800px) and (min-height: 1000px) {
   .qr {
-    width: 360px !important;
-    height: 360px !important;
+    width: min(320px, 28svh, 14vw) !important;
+    height: min(320px, 28svh, 14vw) !important;
   }
 
   .room-code {
-    font-size: 8.4rem;
+    font-size: clamp(3.5rem, 7.5vh, 6.5rem);
+  }
+
+  .room-hero-copy h2 {
+    font-size: clamp(1.85rem, 3.2vh, 2.6rem);
+  }
+
+  .display-grid-lobby .settings-panel {
+    gap: 10px 14px;
+    padding: 18px 22px;
+  }
+
+  .display-grid-lobby .settings-panel .field-label {
+    font-size: 0.95rem;
+  }
+
+  .display-grid-lobby .settings-panel .input {
+    min-height: 40px;
   }
 }
 
 @media (min-width: 3200px) and (min-height: 1800px) {
   .qr {
-    width: 580px !important;
-    height: 580px !important;
+    width: min(420px, 26svh, 12vw) !important;
+    height: min(420px, 26svh, 12vw) !important;
   }
 
   .room-code {
-    font-size: 13.4rem;
+    font-size: clamp(4.5rem, 8vh, 8rem);
+  }
+
+  .room-hero-copy h2 {
+    font-size: clamp(2.1rem, 3.4vh, 3rem);
   }
 }
 

--- a/client/src/design/motion.css
+++ b/client/src/design/motion.css
@@ -1,3 +1,4 @@
+/* Opacity-only: transform + backdrop-filter ghosts text on TV Bro / old WebViews. */
 .fade-rise {
   animation: fade-rise var(--motion-med) var(--ease-out) both;
 }
@@ -5,12 +6,15 @@
 @keyframes fade-rise {
   from {
     opacity: 0;
-    transform: translateY(10px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
+}
+
+.app-shell.display .fade-rise {
+  animation: none;
+  opacity: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/client/src/design/tokens.css
+++ b/client/src/design/tokens.css
@@ -7,6 +7,10 @@
   --surface-glass: rgba(255, 255, 255, 0.08);
   --surface-glass-strong: rgba(255, 255, 255, 0.12);
   --surface-glass-soft: rgba(255, 255, 255, 0.05);
+  /* Opaque TV fills — no backdrop-filter on living-room WebViews. */
+  --surface-tv: rgba(12, 14, 22, 0.88);
+  --surface-tv-soft: rgba(12, 14, 22, 0.78);
+  --surface-tv-strong: rgba(16, 18, 28, 0.92);
   --border-hairline: rgba(255, 255, 255, 0.16);
   --border-strong: rgba(255, 255, 255, 0.28);
   --text-primary: #f5f5f7;

--- a/client/src/views/display/DisplayLobby.tsx
+++ b/client/src/views/display/DisplayLobby.tsx
@@ -65,8 +65,8 @@ export function DisplayLobby(): React.JSX.Element {
       <div className="lobby-side">
         <GlassPanel className="players-panel" tone="soft">
           <div className="panel-title">Players</div>
+          <p className="muted players-count">{playerCountLabel(snapshot.players, snapshot.maxPlayers)}</p>
           <PlayerList players={snapshot.players} showScores />
-          <p className="muted">{playerCountLabel(snapshot.players, snapshot.maxPlayers)}</p>
         </GlassPanel>
         <SettingsPanel settings={settings} onSave={updateSettings} soundOn={soundOn} onToggleSound={toggleSound} />
       </div>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,11 +52,23 @@ Match blast radius for narrow PRs:
 | WebSocket / reconnect / health / static | `cargo test` (incl. `main.rs` tests) |
 | Client logic / protocol | `npm --prefix client test -- --run` + typecheck |
 | UI / layout / touch | Relevant Playwright e2e (include mobile phone contexts) |
+| TV / display layout | `npm run e2e:tv` (required for lobby/display CSS). Optional human glance: `npm run review:tv` then open `client/artifacts/tv-review/index.html` |
 | Protocol constants/messages | Both Rust and TS sides + tests above |
 | Docs only | Link walk + constant accuracy vs code |
 
 `npm run e2e` builds the client, starts the Rust server on `127.0.0.1:3100`, and runs Playwright. Set `E2E_PORT` or `E2E_BASE_URL` as needed.
 
+### TV layout gate (living-room / TV Bro)
+
+Geometric Playwright checks catch the failure modes that pixel snapshots miss on glass UI: clipped hero type, overlapping Players copy, oversized QR/code, and mid-game panels that force page scroll.
+
+```bash
+npm run e2e:tv          # empty + populated lobby + drawing/guessing across TV sizes
+npm run review:tv       # same gate, also writes client/artifacts/tv-review/index.html
+open client/artifacts/tv-review/index.html
+```
+
+CI runs the full e2e suite with `TV_REVIEW=1` and uploads the gallery as the `tv-layout-review` artifact.
 ## Design and protocol
 
 - UI work: follow [design.md](design.md) and [client-ui.md](client-ui.md). CSS belongs under `client/src/design/`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -92,6 +92,8 @@ TV shell: centered, max ~2520px, one composition per phase. Phone shell: max 680
 | Glass base | `.glass-panel`: `backdrop-filter: blur(var(--blur-glass)) saturate(140%)`, hairline border, inset highlight |
 | Soft / strong | `.glass-panel--soft` / `--strong` change fill opacity only; same blur |
 
+TV display shell uses opaque glass fills (no `backdrop-filter`) and skips enter transforms — TV Bro / living-room WebViews otherwise ghost or clip lobby type.
+
 Shadows are soft and short (`0 12px 40px rgba(0,0,0,0.35)`), never hard pixel-offset arcade shadows.
 
 ## 6. Motion

--- a/docs/design.md
+++ b/docs/design.md
@@ -21,6 +21,9 @@ Party play is dark-first (TV living rooms). Tokens below are the product palette
 | Surface glass | `--surface-glass` | `rgba(255, 255, 255, 0.08)` | Panels |
 | Surface glass strong | `--surface-glass-strong` | `rgba(255, 255, 255, 0.12)` | Elevated panels |
 | Surface glass soft | `--surface-glass-soft` | `rgba(255, 255, 255, 0.05)` | Nested wells |
+| Surface TV | `--surface-tv` | `rgba(12, 14, 22, 0.88)` | Display shell opaque glass |
+| Surface TV soft | `--surface-tv-soft` | `rgba(12, 14, 22, 0.78)` | Display soft panels |
+| Surface TV strong | `--surface-tv-strong` | `rgba(16, 18, 28, 0.92)` | Display elevated panels |
 | Border hairline | `--border-hairline` | `rgba(255, 255, 255, 0.16)` | Glass edges |
 | Border strong | `--border-strong` | `rgba(255, 255, 255, 0.28)` | Focused containment |
 | Text primary | `--text-primary` | `#f5f5f7` | Headlines, body |
@@ -90,7 +93,7 @@ TV shell: centered, max ~2520px, one composition per phase. Phone shell: max 680
 |-------|-----------|
 | Atmosphere | Radial glows on deep black |
 | Glass base | `.glass-panel`: `backdrop-filter: blur(var(--blur-glass)) saturate(140%)`, hairline border, inset highlight |
-| Soft / strong | `.glass-panel--soft` / `--strong` change fill opacity only; same blur |
+| Soft / strong | Phone/controller: fill opacity only, same blur. Display shell: use `--surface-tv*` opaque fills with blur disabled |
 
 TV display shell uses opaque glass fills (no `backdrop-filter`) and skips enter transforms — TV Bro / living-room WebViews otherwise ghost or clip lobby type.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "client:test": "npm --prefix client test -- --run",
     "client:typecheck": "npm --prefix client run typecheck",
     "e2e": "npm --prefix client run e2e --",
+    "e2e:tv": "npm --prefix client run e2e:tv --",
+    "review:tv": "npm --prefix client run review:tv --",
     "server:dev": "cargo run --manifest-path server/Cargo.toml",
     "server:test": "cargo test --manifest-path server/Cargo.toml",
     "test": "npm --prefix client test -- --run && npm --prefix client run typecheck && cargo test --manifest-path server/Cargo.toml"


### PR DESCRIPTION
## Summary
- Fix 4K/TV Bro lobby breakage: clipped hero type, overlapping Players copy, and oversized QR/room code.
- Harden display glass/motion for living-room WebViews and keep Players roster stacked with a dedicated layout gate.
- Add `npm run e2e:tv` / `npm run review:tv` plus CI `tv-layout-review` artifact so layout regressions are caught before production.

## Test plan
- [x] Matched validation to blast radius (see `AGENTS.md` / `docs/contributing.md`)
- [ ] Engine / scoring: `cargo test --manifest-path server/Cargo.toml` (if touched)
- [ ] WebSocket / reconnect / health / static: Rust tests including `main.rs` (if touched)
- [ ] Client logic / protocol: `npm --prefix client test -- --run` + typecheck (if touched)
- [x] UI / layout / touch: relevant Playwright e2e, including mobile phone contexts (if touched)
- [x] TV / display layout: `npm run e2e:tv` (if lobby/display CSS touched); optional `npm run review:tv` gallery glance
- [ ] Protocol changes updated both `server/src/protocol.rs` and `client/src/protocol.ts` (+ `docs/protocol.md`)
- [x] Docs updated when architecture, design, or deploy behavior changed

## Notes
- Validated with `npm run review:tv` and `npm run e2e:tv` (empty + populated lobby + drawing/guessing across TV sizes).
- After CI, check the `tv-layout-review` artifact gallery for a quick human glance.