### PR TITLE
chore(ci): bump checkout and setup-node to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` and `actions/setup-node` from v4 to v7 in one PR (avoids sequential ci.yml conflicts).
- Supersedes Dependabot #51 and #52.

## Test plan
- [x] CI validate on this PR
- [ ] Close #51 and #52 after merge