### PR TITLE
Update TV lobby catchphrase copy

### DIFF
--- a/client/e2e/polish.e2e.ts
+++ b/client/e2e/polish.e2e.ts
@@ -83,7 +83,7 @@ test('TV lobby gives room code and QR the showcase hierarchy', async ({ baseURL,
     await expect(page.locator('.room-code')).toHaveText(/[A-Z]{4}/);
     await expect(page.locator('.qr')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Start Game' })).toBeVisible();
-    await expect(page.getByText('Everybody draws. Everybody lies.')).toBeVisible();
+    await expect(page.getByText('Everybody draws. Everybody guesses.')).toBeVisible();
     await expect(page.locator('.settings-panel')).toBeVisible();
     await expectNoVerticalOverflow(page);
 

--- a/client/e2e/tv-layout.ts
+++ b/client/e2e/tv-layout.ts
@@ -111,7 +111,7 @@ export async function assertDisplayLobbyLayout(
   await expect(page.locator('.room-code')).toHaveText(/[A-Z]{4}/);
   await expect(page.locator('.qr')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Start Game' })).toBeVisible();
-  await expect(page.getByText('Everybody draws. Everybody lies.')).toBeVisible();
+  await expect(page.getByText('Everybody draws. Everybody guesses.')).toBeVisible();
   await expectNoHorizontalOverflow(page);
   await expectNoVerticalOverflow(page);
 

--- a/client/src/views/display/DisplayLobby.tsx
+++ b/client/src/views/display/DisplayLobby.tsx
@@ -38,8 +38,8 @@ export function DisplayLobby(): React.JSX.Element {
       <GlassPanel className="room-panel">
         <div className="room-hero-copy">
           <p className="eyebrow">Scan to play</p>
-          <h2>Everybody draws. Everybody lies.</h2>
-          <p className="muted room-hero-sub">Phones scan the QR or type the code. First laugh in under a minute.</p>
+          <h2>Everybody draws. Everybody guesses.</h2>
+          <p className="muted room-hero-sub">Phones scan the QR or type the code.</p>
         </div>
         <div className="room-code-wrap">
           <span className="room-code-label">Room Code</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces the TV lobby catchphrase `Everybody draws. Everybody lies.` with `Everybody draws. Everybody guesses.`
- Removes the promo line `First laugh in under a minute.`
- Updates polish and TV layout e2e assertions to match

## Test plan
- [ ] Open the display lobby and confirm the new headline and shortened subcopy
- [ ] Confirm Start Game / QR / room code layout still reads cleanly on TV
- [ ] Relevant e2e: polish / TV layout lobby text assertions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91058780-2808-4e5f-9fb2-ed41ad1e4842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91058780-2808-4e5f-9fb2-ed41ad1e4842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

