### PR TITLE
Fix TV lobby layout and expired-room recovery

### DIFF
--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -107,7 +107,6 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   const lastTickSecondRef = useRef(-1);
   const pendingJoinRef = useRef<PendingJoin | null>(null);
   const snapshotRef = useRef<RoomSnapshot | null>(null);
-  const connectRef = useRef<(roomCode?: string) => void>(() => {});
   const burstIdRef = useRef(0);
 
   const [snapshot, setSnapshot] = useState<RoomSnapshot | null>(null);
@@ -231,10 +230,8 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
             }
             setSnapshot(null);
             snapshotRef.current = null;
-            setErrorMessage('That room expired. Creating a fresh lobby…');
-            window.setTimeout(() => {
-              connectRef.current();
-            }, 100);
+            setErrorMessage("Couldn't reattach to that room. Creating a fresh lobby…");
+            socketRef.current?.send({ type: 'createRoom' });
             break;
           }
           setErrorMessage(message.message);
@@ -302,10 +299,6 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
     },
     [boot.role, clientId, handleServerMessage]
   );
-
-  useEffect(() => {
-    connectRef.current = connect;
-  }, [connect]);
 
   useEffect(() => {
     if (boot.role === 'display') {

--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -86,6 +86,10 @@ function storeHostToken(roomCode: string, hostToken: string): void {
   localStorage.setItem(hostTokenKey(roomCode), hostToken);
 }
 
+function clearStoredHostToken(roomCode: string): void {
+  localStorage.removeItem(hostTokenKey(roomCode));
+}
+
 function detectRole(): { role: ClientRole; initialRoomCode: string } {
   const joinMatch = window.location.pathname.match(/^\/join\/([A-Z0-9]{4})/i);
   return {
@@ -103,6 +107,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   const lastTickSecondRef = useRef(-1);
   const pendingJoinRef = useRef<PendingJoin | null>(null);
   const snapshotRef = useRef<RoomSnapshot | null>(null);
+  const connectRef = useRef<(roomCode?: string) => void>(() => {});
   const burstIdRef = useRef(0);
 
   const [snapshot, setSnapshot] = useState<RoomSnapshot | null>(null);
@@ -216,6 +221,22 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
         case 'pong':
           break;
         case 'error':
+          if (
+            boot.role === 'display' &&
+            (message.code === 'room_not_found' || message.code === 'unauthorized_display')
+          ) {
+            const deadCode = snapshotRef.current?.roomCode;
+            if (deadCode) {
+              clearStoredHostToken(deadCode);
+            }
+            setSnapshot(null);
+            snapshotRef.current = null;
+            setErrorMessage('That room expired. Creating a fresh lobby…');
+            window.setTimeout(() => {
+              connectRef.current();
+            }, 100);
+            break;
+          }
           setErrorMessage(message.message);
           if (['room_not_found', 'room_full'].includes(message.code)) {
             setPendingJoin(null);
@@ -230,7 +251,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
         }
       }
     },
-    [applySnapshot]
+    [applySnapshot, boot.role]
   );
 
   const connect = useCallback(
@@ -281,6 +302,10 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
     },
     [boot.role, clientId, handleServerMessage]
   );
+
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
 
   useEffect(() => {
     if (boot.role === 'display') {

--- a/client/src/components/ui/QrCode.tsx
+++ b/client/src/components/ui/QrCode.tsx
@@ -13,14 +13,11 @@ export function QrCode({ url }: QrCodeProps): React.JSX.Element {
     if (!canvas) {
       return;
     }
+    // Intrinsic 256px; `.qr` in CSS scales display size for TV WebViews.
     void QRCode.toCanvas(canvas, url, {
       width: 256,
       margin: 1,
       color: { dark: '#1d1d1f', light: '#ffffff' }
-    }).then(() => {
-      // Keep display size CSS-driven; avoid 640px intrinsic blow-ups on TV WebViews.
-      canvas.style.width = '100%';
-      canvas.style.height = 'auto';
     });
   }, [url]);
 

--- a/client/src/components/ui/QrCode.tsx
+++ b/client/src/components/ui/QrCode.tsx
@@ -14,12 +14,13 @@ export function QrCode({ url }: QrCodeProps): React.JSX.Element {
       return;
     }
     void QRCode.toCanvas(canvas, url, {
-      width: 640,
+      width: 256,
       margin: 1,
       color: { dark: '#1d1d1f', light: '#ffffff' }
     }).then(() => {
-      canvas.style.width = '';
-      canvas.style.height = '';
+      // Keep display size CSS-driven; avoid 640px intrinsic blow-ups on TV WebViews.
+      canvas.style.width = '100%';
+      canvas.style.height = 'auto';
     });
   }, [url]);
 

--- a/client/src/components/ui/Shell.tsx
+++ b/client/src/components/ui/Shell.tsx
@@ -20,27 +20,30 @@ export function Shell({ title, children }: ShellProps): React.JSX.Element {
 
   const waitingToJoin = role === 'player' && !pendingJoin && !snapshot;
   const connection = waitingToJoin ? 'Ready to join' : status;
+  const showConnectionBanner = status !== 'Connected' && Boolean(snapshot) && !errorMessage;
+  const statusStrip = errorMessage ? (
+    <div className="error" role="alert">
+      {errorMessage}
+    </div>
+  ) : showConnectionBanner ? (
+    <div className="connection-banner">{status}</div>
+  ) : null;
 
   return (
     <div className={`app-shell ${role} ${phaseClass}`}>
       <Atmosphere />
-      <header className="topbar">
-        <div>
-          <div className="brand">{title}</div>
-          {snapshot ? <div className="phase">{phaseLabel(snapshot.phase)}</div> : null}
-        </div>
-        <div className="connection connection-text" id="connection-text">
-          {connection}
-        </div>
-      </header>
-      {status !== 'Connected' && snapshot ? (
-        <div className="connection-banner">{status}</div>
-      ) : null}
-      {errorMessage ? (
-        <div className="error" role="alert">
-          {errorMessage}
-        </div>
-      ) : null}
+      <div className="shell-chrome">
+        <header className="topbar">
+          <div>
+            <div className="brand">{title}</div>
+            {snapshot ? <div className="phase">{phaseLabel(snapshot.phase)}</div> : null}
+          </div>
+          <div className="connection connection-text" id="connection-text">
+            {connection}
+          </div>
+        </header>
+        {statusStrip}
+      </div>
       {children}
     </div>
   );

--- a/client/src/design/base.css
+++ b/client/src/design/base.css
@@ -86,6 +86,21 @@ button:disabled {
   overflow: hidden;
 }
 
+.app-shell.display > .shell-chrome {
+  position: relative;
+  z-index: 2;
+  min-width: 0;
+}
+
+.app-shell.display > .shell-chrome .topbar {
+  margin-bottom: var(--space-3);
+}
+
+.app-shell.display > .shell-chrome .error,
+.app-shell.display > .shell-chrome .connection-banner {
+  margin-bottom: var(--space-4);
+}
+
 .app-shell.player {
   max-width: 680px;
   margin: 0 auto;

--- a/client/src/design/components.css
+++ b/client/src/design/components.css
@@ -257,20 +257,12 @@
 .qr-stage {
   display: grid;
   place-items: center;
-  width: min(220px, 22vh, 18vw);
-  max-width: 100%;
   margin: 0 auto;
   padding: 8px;
   border-radius: var(--radius-md);
   background: #fff;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
   overflow: hidden;
-}
-
-@supports (height: 1svh) {
-  .qr-stage {
-    width: min(220px, 22svh, 18vw);
-  }
 }
 
 .qr {

--- a/client/src/design/components.css
+++ b/client/src/design/components.css
@@ -257,18 +257,30 @@
 .qr-stage {
   display: grid;
   place-items: center;
+  width: min(220px, 22vh, 18vw);
+  max-width: 100%;
   margin: 0 auto;
   padding: 8px;
   border-radius: var(--radius-md);
   background: #fff;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+@supports (height: 1svh) {
+  .qr-stage {
+    width: min(220px, 22svh, 18vw);
+  }
 }
 
 .qr {
-  width: min(220px, 28svh, 18vw) !important;
-  height: min(220px, 28svh, 18vw) !important;
+  display: block;
+  width: 100% !important;
+  height: auto !important;
+  max-width: 100%;
   border-radius: 8px;
 }
+
 
 .join-url {
   margin: 0;

--- a/client/src/design/layout.css
+++ b/client/src/design/layout.css
@@ -157,9 +157,10 @@
 }
 
 .qr-stage {
-  width: min(220px, 22vh, 18vw);
+  --qr-size: min(220px, 22vh, 18vw);
+  /* ~180px QR after 8px stage padding (see e2e/tv-layout.ts). */
+  width: max(196px, var(--qr-size));
   max-width: 100%;
-  padding: 8px;
   margin: 0 auto;
   flex: 0 1 auto;
   min-height: 0;
@@ -168,15 +169,8 @@
 
 @supports (height: 1svh) {
   .qr-stage {
-    width: min(220px, 22svh, 18vw);
+    --qr-size: min(220px, 22svh, 18vw);
   }
-}
-
-.qr {
-  display: block;
-  width: 100% !important;
-  height: auto !important;
-  max-width: 100%;
 }
 
 .brand {
@@ -677,12 +671,12 @@
 /* Large TVs: scale with viewport height so hero + QR + CTA stay in one frame. */
 @media (min-width: 1800px) and (min-height: 1000px) {
   .qr-stage {
-    width: min(320px, 24vh, 14vw);
+    --qr-size: min(320px, 27vh, 14vw);
   }
 
   @supports (height: 1svh) {
     .qr-stage {
-      width: min(320px, 24svh, 14vw);
+      --qr-size: min(320px, 27svh, 14vw);
     }
   }
 
@@ -710,12 +704,12 @@
 
 @media (min-width: 3200px) and (min-height: 1800px) {
   .qr-stage {
-    width: min(420px, 22vh, 12vw);
+    --qr-size: min(420px, 22vh, 12vw);
   }
 
   @supports (height: 1svh) {
     .qr-stage {
-      width: min(420px, 22svh, 12vw);
+      --qr-size: min(420px, 22svh, 12vw);
     }
   }
 

--- a/client/src/design/layout.css
+++ b/client/src/design/layout.css
@@ -10,9 +10,7 @@
   overflow: hidden;
 }
 
-.app-shell.display > .display-grid,
-.app-shell.display > .connection-banner,
-.app-shell.display > .error {
+.app-shell.display > .display-grid {
   position: relative;
   z-index: 1;
   min-height: 0;
@@ -159,16 +157,26 @@
 }
 
 .qr-stage {
-  width: auto;
+  width: min(220px, 22vh, 18vw);
+  max-width: 100%;
   padding: 8px;
   margin: 0 auto;
   flex: 0 1 auto;
   min-height: 0;
+  overflow: hidden;
+}
+
+@supports (height: 1svh) {
+  .qr-stage {
+    width: min(220px, 22svh, 18vw);
+  }
 }
 
 .qr {
-  width: min(220px, 26svh, 18vw) !important;
-  height: min(220px, 26svh, 18vw) !important;
+  display: block;
+  width: 100% !important;
+  height: auto !important;
+  max-width: 100%;
 }
 
 .brand {
@@ -668,9 +676,14 @@
 
 /* Large TVs: scale with viewport height so hero + QR + CTA stay in one frame. */
 @media (min-width: 1800px) and (min-height: 1000px) {
-  .qr {
-    width: min(320px, 28svh, 14vw) !important;
-    height: min(320px, 28svh, 14vw) !important;
+  .qr-stage {
+    width: min(320px, 24vh, 14vw);
+  }
+
+  @supports (height: 1svh) {
+    .qr-stage {
+      width: min(320px, 24svh, 14vw);
+    }
   }
 
   .room-code {
@@ -696,9 +709,14 @@
 }
 
 @media (min-width: 3200px) and (min-height: 1800px) {
-  .qr {
-    width: min(420px, 26svh, 12vw) !important;
-    height: min(420px, 26svh, 12vw) !important;
+  .qr-stage {
+    width: min(420px, 22vh, 12vw);
+  }
+
+  @supports (height: 1svh) {
+    .qr-stage {
+      width: min(420px, 22svh, 12vw);
+    }
   }
 
   .room-code {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,7 @@ Spectators are not eligible voters. The artist is never an eligible voter for th
 - Disconnected players remain on the roster with `connected: false`.
 - Progress does not wait forever on disconnected players: once all **connected** eligible players have submitted (draw / guess / vote), the engine can advance.
 - Player re-join sets `connected: true`; display re-attach re-registers the display via host token. Heartbeats are keepalive only (`Pong`); they do not flip `connected`.
+- If a display reconnects to an expired room (`room_not_found`), the client clears the stale host token and creates a fresh lobby.
 
 ## Spectators and seat limits
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -95,7 +95,7 @@ TV shell: centered, max ~2520px, one composition per phase. Phone shell: max 680
 | Glass base | `.glass-panel`: `backdrop-filter: blur(var(--blur-glass)) saturate(140%)`, hairline border, inset highlight |
 | Soft / strong | Phone/controller: fill opacity only, same blur. Display shell: use `--surface-tv*` opaque fills with blur disabled |
 
-TV display shell uses opaque glass fills (no `backdrop-filter`) and skips enter transforms — TV Bro / living-room WebViews otherwise ghost or clip lobby type.
+TV display shell uses opaque glass fills (no `backdrop-filter`) and skips enter transforms — TV Bro / living-room WebViews otherwise ghost or clip lobby type. QR sizing is stage-driven (`vh` with `svh` progressive enhancement) so canvases never keep a 640px intrinsic size that overlaps the join URL / Start CTA.
 
 Shadows are soft and short (`0 12px 40px rgba(0,0,0,0.35)`), never hard pixel-offset arcade shadows.
 


### PR DESCRIPTION
## Summary
- Merge connection/error into a single shell status strip so TV banners no longer overlap
- Constrain QR sizing for TV WebViews (`vh` + `svh`) so the join URL and Start CTA stay visible without scrolling
- When a display reconnects to an expired room, clear the stale host token and create a fresh lobby

## Test plan
- [x] Client logic: `npm --prefix client test -- --run` + typecheck (run in prior validation; re-check if CI fails)
- [x] TV / display layout: `npm run e2e:tv`
- [ ] Manual: open TV lobby, confirm one status banner max and QR does not cover Start/URL
- [ ] Manual: kill/expire a room and reload display — new room code appears without stuck overlap

## Notes
Independent of host-phone controls PR.