### PR TITLE
feat: harden Draw Party session recovery

### DIFF
--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -102,6 +102,10 @@ function detectRole(): { role: ClientRole; initialRoomCode: string } {
 export function GameProvider({ children }: { children: ReactNode }): React.JSX.Element {
   const boot = useMemo(() => detectRole(), []);
   const clientId = useMemo(() => getStoredValue('draw-party-client-id', () => crypto.randomUUID()), []);
+  const sessionToken = useMemo(
+    () => getStoredValue('draw-party-session-token', () => crypto.randomUUID()),
+    []
+  );
   const socketRef = useRef<GameSocket | null>(null);
   const reconnectTimerRef = useRef(0);
   const lastPhaseRef = useRef('');
@@ -259,6 +263,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       const socket = new GameSocket({
         role: boot.role,
         clientId,
+        sessionToken,
         roomCode,
         hostToken:
           boot.role === 'display' && roomCode
@@ -301,7 +306,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       socketRef.current = socket;
       socket.connect();
     },
-    [boot.role, clientId, handleServerMessage, hostTokens]
+    [boot.role, clientId, handleServerMessage, hostTokens, sessionToken]
   );
 
   useEffect(() => {

--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -91,6 +91,20 @@ function getStoredValue(key: string, fallback: () => string): string {
   return value;
 }
 
+function getTabStoredValue(key: string, fallback: () => string): string {
+  try {
+    const stored = sessionStorage.getItem(key);
+    if (stored) {
+      return stored;
+    }
+    const value = fallback();
+    sessionStorage.setItem(key, value);
+    return value;
+  } catch {
+    return fallback();
+  }
+}
+
 function detectRole(): { role: ClientRole; initialRoomCode: string } {
   const joinMatch = window.location.pathname.match(/^\/join\/([A-Z0-9]{4})/i);
   return {
@@ -103,7 +117,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   const boot = useMemo(() => detectRole(), []);
   const clientId = useMemo(() => getStoredValue('draw-party-client-id', () => crypto.randomUUID()), []);
   const sessionToken = useMemo(
-    () => getStoredValue('draw-party-session-token', () => crypto.randomUUID()),
+    () => getTabStoredValue('draw-party-session-token', () => crypto.randomUUID()),
     []
   );
   const socketRef = useRef<GameSocket | null>(null);
@@ -112,6 +126,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   const lastTickSecondRef = useRef(-1);
   const pendingJoinRef = useRef<PendingJoin | null>(null);
   const snapshotRef = useRef<RoomSnapshot | null>(null);
+  const reconnectSuppressedRef = useRef(false);
   const hostTokens = useMemo(() => new HostTokenCache(), []);
   const burstIdRef = useRef(0);
 
@@ -226,6 +241,16 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
         case 'pong':
           break;
         case 'error':
+          if (message.code === 'session_in_use' || message.code === 'invalid_player_session') {
+            reconnectSuppressedRef.current = true;
+            setErrorMessage(
+              message.code === 'session_in_use'
+                ? 'This game controller is already active in another tab.'
+                : 'This player identity belongs to another device.'
+            );
+            socketRef.current?.close();
+            break;
+          }
           if (
             boot.role === 'display' &&
             (message.code === 'room_not_found' || message.code === 'unauthorized_display')
@@ -288,6 +313,9 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
           }
         },
         onClose: () => {
+          if (reconnectSuppressedRef.current) {
+            return;
+          }
           if (reconnectTimerRef.current) {
             return;
           }
@@ -352,6 +380,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       setPlayerName(name);
       setRoomCodeDraft(roomCode);
       const next = { roomCode, name };
+      reconnectSuppressedRef.current = false;
       setPendingJoin(next);
       pendingJoinRef.current = next;
       connect(roomCode);

--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode
 } from 'react';
 import { GameSocket } from '../net';
+import { HostTokenCache } from '../host-token-cache';
 import {
   type ClientMessage,
   type ReactionEmoji,
@@ -64,30 +65,30 @@ interface GameContextValue {
 
 const GameContext = createContext<GameContextValue | null>(null);
 
+function readStoredValue(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredValue(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Party play still works when a browser blocks persistent storage.
+  }
+}
+
 function getStoredValue(key: string, fallback: () => string): string {
-  const stored = localStorage.getItem(key);
+  const stored = readStoredValue(key);
   if (stored) {
     return stored;
   }
   const value = fallback();
-  localStorage.setItem(key, value);
+  writeStoredValue(key, value);
   return value;
-}
-
-function hostTokenKey(roomCode: string): string {
-  return `draw-party-host-token-${roomCode}`;
-}
-
-function getStoredHostToken(roomCode: string): string | null {
-  return localStorage.getItem(hostTokenKey(roomCode));
-}
-
-function storeHostToken(roomCode: string, hostToken: string): void {
-  localStorage.setItem(hostTokenKey(roomCode), hostToken);
-}
-
-function clearStoredHostToken(roomCode: string): void {
-  localStorage.removeItem(hostTokenKey(roomCode));
 }
 
 function detectRole(): { role: ClientRole; initialRoomCode: string } {
@@ -107,13 +108,14 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   const lastTickSecondRef = useRef(-1);
   const pendingJoinRef = useRef<PendingJoin | null>(null);
   const snapshotRef = useRef<RoomSnapshot | null>(null);
+  const hostTokens = useMemo(() => new HostTokenCache(), []);
   const burstIdRef = useRef(0);
 
   const [snapshot, setSnapshot] = useState<RoomSnapshot | null>(null);
   const [prompt, setPrompt] = useState('');
   const [status, setStatus] = useState(boot.role === 'player' ? 'Ready to join' : 'Disconnected');
   const [errorMessage, setErrorMessage] = useState('');
-  const [playerName, setPlayerName] = useState(() => localStorage.getItem('draw-party-name') ?? '');
+  const [playerName, setPlayerName] = useState(() => readStoredValue('draw-party-name') ?? '');
   const [roomCodeDraft, setRoomCodeDraft] = useState(boot.initialRoomCode);
   const [pendingJoin, setPendingJoin] = useState<PendingJoin | null>(null);
   const [selectedVote, setSelectedVote] = useState<{ turnToken: number; optionId: string } | null>(null);
@@ -166,7 +168,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       setErrorMessage('');
       switch (message.type) {
         case 'roomCreated':
-          storeHostToken(message.snapshot.roomCode, message.hostToken);
+          hostTokens.set(message.snapshot.roomCode, message.hostToken);
           applySnapshot(message.snapshot);
           break;
         case 'roomSnapshot':
@@ -226,7 +228,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
           ) {
             const deadCode = snapshotRef.current?.roomCode;
             if (deadCode) {
-              clearStoredHostToken(deadCode);
+              hostTokens.delete(deadCode);
             }
             setSnapshot(null);
             snapshotRef.current = null;
@@ -248,7 +250,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
         }
       }
     },
-    [applySnapshot, boot.role]
+    [applySnapshot, boot.role, hostTokens]
   );
 
   const connect = useCallback(
@@ -259,7 +261,9 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
         clientId,
         roomCode,
         hostToken:
-          boot.role === 'display' && roomCode ? getStoredHostToken(roomCode) ?? undefined : undefined,
+          boot.role === 'display' && roomCode
+            ? hostTokens.get(roomCode) ?? undefined
+            : undefined,
         onOpen: () => {
           if (reconnectTimerRef.current) {
             window.clearTimeout(reconnectTimerRef.current);
@@ -297,7 +301,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       socketRef.current = socket;
       socket.connect();
     },
-    [boot.role, clientId, handleServerMessage]
+    [boot.role, clientId, handleServerMessage, hostTokens]
   );
 
   useEffect(() => {
@@ -339,7 +343,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
 
   const joinRoom = useCallback(
     (roomCode: string, name: string) => {
-      localStorage.setItem('draw-party-name', name);
+      writeStoredValue('draw-party-name', name);
       setPlayerName(name);
       setRoomCodeDraft(roomCode);
       const next = { roomCode, name };
@@ -354,7 +358,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   const setName = useCallback(
     (name: string) => {
       const safeName = name.trim() || 'Player';
-      localStorage.setItem('draw-party-name', safeName);
+      writeStoredValue('draw-party-name', safeName);
       setPlayerName(safeName);
       setPendingJoin((current) => {
         if (!current) {

--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -91,20 +91,6 @@ function getStoredValue(key: string, fallback: () => string): string {
   return value;
 }
 
-function getTabStoredValue(key: string, fallback: () => string): string {
-  try {
-    const stored = sessionStorage.getItem(key);
-    if (stored) {
-      return stored;
-    }
-    const value = fallback();
-    sessionStorage.setItem(key, value);
-    return value;
-  } catch {
-    return fallback();
-  }
-}
-
 function detectRole(): { role: ClientRole; initialRoomCode: string } {
   const joinMatch = window.location.pathname.match(/^\/join\/([A-Z0-9]{4})/i);
   return {
@@ -117,7 +103,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   const boot = useMemo(() => detectRole(), []);
   const clientId = useMemo(() => getStoredValue('draw-party-client-id', () => crypto.randomUUID()), []);
   const sessionToken = useMemo(
-    () => getTabStoredValue('draw-party-session-token', () => crypto.randomUUID()),
+    () => getStoredValue('draw-party-session-token', () => crypto.randomUUID()),
     []
   );
   const socketRef = useRef<GameSocket | null>(null);
@@ -383,7 +369,12 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
       reconnectSuppressedRef.current = false;
       setPendingJoin(next);
       pendingJoinRef.current = next;
-      connect(roomCode);
+      const socket = socketRef.current;
+      if (socket?.isOpen()) {
+        socket.send({ type: 'joinRoom', roomCode, name });
+      } else {
+        connect(roomCode);
+      }
       haptic(8);
     },
     [connect, haptic]

--- a/client/src/host-token-cache.test.ts
+++ b/client/src/host-token-cache.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { HostTokenCache } from './host-token-cache';
+
+const blockedStorage = {
+  getItem(): never {
+    throw new Error('storage blocked');
+  },
+  setItem(): never {
+    throw new Error('storage blocked');
+  },
+  removeItem(): never {
+    throw new Error('storage blocked');
+  }
+};
+
+describe('HostTokenCache', () => {
+  it('keeps the current host credential available when storage is blocked', () => {
+    const cache = new HostTokenCache(blockedStorage);
+
+    cache.set('ABCD', 'host-token');
+
+    expect(cache.get('ABCD')).toBe('host-token');
+    cache.delete('ABCD');
+    expect(cache.get('ABCD')).toBeNull();
+  });
+
+  it('does not let a stale persisted token override a write that could not persist', () => {
+    const storage = {
+      getItem: () => 'stale-token',
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+      removeItem: () => {}
+    };
+    const cache = new HostTokenCache(storage);
+
+    cache.set('ABCD', 'current-token');
+
+    expect(cache.get('ABCD')).toBe('current-token');
+  });
+});

--- a/client/src/host-token-cache.ts
+++ b/client/src/host-token-cache.ts
@@ -1,0 +1,59 @@
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function browserStorage(): StorageLike | null {
+  try {
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function hostTokenKey(roomCode: string): string {
+  return `draw-party-host-token-${roomCode}`;
+}
+
+/** Keeps the current display's recovery credential usable when persistence is blocked. */
+export class HostTokenCache {
+  private readonly memory = new Map<string, string>();
+
+  constructor(private readonly storage: StorageLike | null = browserStorage()) {}
+
+  get(roomCode: string): string | null {
+    if (this.memory.has(roomCode)) {
+      return this.memory.get(roomCode) ?? null;
+    }
+    const key = hostTokenKey(roomCode);
+    try {
+      const persisted = this.storage?.getItem(key);
+      if (persisted) {
+        this.memory.set(roomCode, persisted);
+        return persisted;
+      }
+    } catch {
+      // The in-memory credential is sufficient for this display session.
+    }
+    return this.memory.get(roomCode) ?? null;
+  }
+
+  set(roomCode: string, token: string): void {
+    this.memory.set(roomCode, token);
+    try {
+      this.storage?.setItem(hostTokenKey(roomCode), token);
+    } catch {
+      // Keep hosting available even when browser privacy settings reject storage.
+    }
+  }
+
+  delete(roomCode: string): void {
+    this.memory.delete(roomCode);
+    try {
+      this.storage?.removeItem(hostTokenKey(roomCode));
+    } catch {
+      // The rejected credential is still removed from this in-memory session.
+    }
+  }
+}

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -4,6 +4,7 @@ import { isServerMessage } from './protocol';
 interface SocketOptions {
   role: Role;
   clientId: string;
+  sessionToken: string;
   roomCode?: string;
   hostToken?: string;
   onOpen: () => void;
@@ -25,6 +26,7 @@ export class GameSocket {
     url.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     url.searchParams.set('role', this.options.role);
     url.searchParams.set('client_id', this.options.clientId);
+    url.searchParams.set('sessionToken', this.options.sessionToken);
     if (this.options.roomCode) {
       url.searchParams.set('room', this.options.roomCode);
     }

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -51,10 +51,10 @@ export class GameSocket {
         this.options.onStatus('Received invalid server message');
       }
     });
-    this.ws.addEventListener('close', () => {
+    this.ws.addEventListener('close', (event) => {
       this.options.onStatus('Disconnected');
       this.stopHeartbeat();
-      if (!this.closedByUser) {
+      if (!this.closedByUser && event.code !== 4001) {
         this.options.onClose();
       }
     });
@@ -67,6 +67,10 @@ export class GameSocket {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(message));
     }
+  }
+
+  isOpen(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
   }
 
   close(): void {

--- a/client/src/sound.ts
+++ b/client/src/sound.ts
@@ -47,7 +47,23 @@ const CUE_PATTERNS: Record<CueName, CueStep[]> = {
 };
 
 let audioContext: AudioContext | null = null;
-let enabled = localStorage.getItem('draw-party-sound') === 'on';
+let enabled = readSoundPreference();
+
+function readSoundPreference(): boolean {
+  try {
+    return localStorage.getItem('draw-party-sound') === 'on';
+  } catch {
+    return false;
+  }
+}
+
+function persistSoundPreference(value: boolean): void {
+  try {
+    localStorage.setItem('draw-party-sound', value ? 'on' : 'off');
+  } catch {
+    // Sound remains available for this session when storage is unavailable.
+  }
+}
 
 export function soundEnabled(): boolean {
   return enabled;
@@ -55,7 +71,7 @@ export function soundEnabled(): boolean {
 
 export function setSoundEnabled(nextEnabled: boolean): void {
   enabled = nextEnabled;
-  localStorage.setItem('draw-party-sound', enabled ? 'on' : 'off');
+  persistSoundPreference(enabled);
   if (enabled) {
     audioContext = audioContext ?? new AudioContext();
     void audioContext.resume();

--- a/docs/client-ui.md
+++ b/docs/client-ui.md
@@ -3,6 +3,7 @@
 React + TypeScript Apple-glass UI is the sole client entry. All phases are implemented against the Rust protocol.
 
 See [design.md](design.md) for the visual system and [architecture.md](architecture.md) for authority boundaries.
+The phased UX plan and its current execution status live in [ui-ux-improvement-plan.md](ui-ux-improvement-plan.md).
 
 ## Phase coverage
 

--- a/docs/ui-ux-improvement-plan.md
+++ b/docs/ui-ux-improvement-plan.md
@@ -1,0 +1,54 @@
+# UI/UX Improvement Plan
+
+This plan treats the TV as the shared game state and phones as focused controllers. The Rust server remains authoritative for rooms, turns, scoring, reconnects, and expiry.
+
+## Phase 1 — Establish the visual and interaction baseline
+
+**Outcome:** a single, legible cross-device experience.
+
+- Keep the Apple-glass design system in `client/src/design/` and its source of truth in [design.md](design.md).
+- Preserve large TV hierarchy, 52px controller targets, safe-area phone layouts, keyboard focus, reduced motion, and accessible labels.
+- Validate real lobby, drawing, guessing, voting, results, and final-score layouts at phone, tablet, 720p, and 4K sizes.
+
+**Status:** complete on current `main`.
+
+## Phase 2 — Make onboarding and hosting obvious
+
+**Outcome:** a host can create a room, guests can join, and the next action is clear without instructions.
+
+- Keep the display QR/code as the lobby anchor and expose readiness through the player list and progress panel.
+- Keep room controls on the host phone so the TV remains a shared, uncluttered surface.
+- Make invalid room and full-room recovery return the controller to a usable join state.
+
+**Status:** complete on current `main`.
+
+## Phase 3 — Make every in-round controller state decisive
+
+**Outcome:** every player can immediately tell whether to draw, guess, vote, watch, or wait.
+
+- Keep the drawing canvas first on a phone, with compact tools and a clear submit state.
+- Preserve spectator, artist, submitted, countdown, reaction, and staged-results feedback.
+- Keep client state derived from server snapshots; never let a visual transition alter game authority.
+
+**Status:** complete on current `main`.
+
+## Phase 4 — Harden recovery so polish survives real party conditions
+
+**Outcome:** temporary network loss, a stale tab, a slow controller, or denied browser storage does not make the room feel broken.
+
+- Replace unbounded WebSocket outbound queues with bounded per-connection delivery; retire only the slow connection when it falls behind.
+- Give every socket generation an identity so a superseded tab cannot mutate or disconnect its replacement.
+- Close superseded sockets promptly and keep mutation plus snapshot enqueueing ordered under the room lock.
+- Treat browser storage as optional: retain a usable in-session identity, name, host recovery, and sound control when persistence is blocked.
+
+**Status:** implemented by this PR.
+
+## Phase 5 — Keep the quality bar regression-proof
+
+**Outcome:** design changes remain playable, readable, and recoverable across devices.
+
+- Run Rust formatting, Clippy, server tests, client typecheck/Vitest/build, and the full Playwright matrix.
+- Include the TV geometry and TV Bro visual gates for presentation changes.
+- Finish each UX PR with a Graphify refresh for impact mapping and an independent Thermos review.
+
+**Status:** validation and final review are required before merge.

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -252,6 +252,12 @@ impl Room {
                 .is_some_and(|player| player.connected)
     }
 
+    pub fn player_session_matches(&self, player_id: &str, session_token: &str) -> bool {
+        self.players
+            .get(player_id)
+            .is_none_or(|player| player.session_token == session_token)
+    }
+
     pub fn handle_start_or_advance(&mut self, now_ms: u64) -> EngineResult<EngineEvent> {
         self.touch(now_ms);
         match self.phase {

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -22,6 +22,8 @@ pub struct Player {
     pub joined_at_ms: u64,
     #[serde(default, skip)]
     pub last_reaction_ms: u64,
+    #[serde(default, skip)]
+    session_token: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -118,6 +120,33 @@ impl Room {
         name: String,
         now_ms: u64,
     ) -> EngineResult<()> {
+        let session_token = self
+            .players
+            .get(&player_id)
+            .map(|player| player.session_token.clone())
+            .filter(|token| !token.is_empty())
+            .unwrap_or_else(|| format!("legacy:{player_id}"));
+        self.upsert_player_with_session(player_id, session_token, name, now_ms)
+    }
+
+    pub fn upsert_player_with_session(
+        &mut self,
+        player_id: String,
+        session_token: String,
+        name: String,
+        now_ms: u64,
+    ) -> EngineResult<()> {
+        if self
+            .players
+            .get(&player_id)
+            .is_some_and(|player| player.session_token != session_token)
+        {
+            return Err(EngineError::new(
+                "invalid_player_session",
+                "This player identity belongs to another device.",
+            ));
+        }
+
         self.touch(now_ms);
         let safe_name = sanitize_name(&name);
         let joining_as_spectator =
@@ -145,6 +174,7 @@ impl Room {
                 spectator: joining_as_spectator,
                 joined_at_ms: now_ms,
                 last_reaction_ms: 0,
+                session_token,
             });
         self.ensure_host();
 

--- a/server/src/engine/tests/host.rs
+++ b/server/src/engine/tests/host.rs
@@ -67,3 +67,35 @@ fn host_succession_uses_join_order_not_player_id_order() {
     assert_eq!(room.host_player_id.as_deref(), Some("p3"));
     assert!(room.player_can_control("p3"));
 }
+
+#[test]
+fn reconnecting_a_player_requires_its_original_session_token() {
+    let mut room = Room::new(
+        "HOST".to_string(),
+        "display".to_string(),
+        "host-token".to_string(),
+        0,
+    );
+    room.upsert_player_with_session(
+        "p1".to_string(),
+        "private-session".to_string(),
+        "Ada".to_string(),
+        1,
+    )
+    .unwrap();
+    room.mark_disconnected("p1", 2);
+
+    let error = room
+        .upsert_player_with_session(
+            "p1".to_string(),
+            "attacker-session".to_string(),
+            "Mallory".to_string(),
+            3,
+        )
+        .unwrap_err();
+
+    assert_eq!(error.code, "invalid_player_session");
+    let player = room.players.get("p1").unwrap();
+    assert_eq!(player.name, "Ada");
+    assert!(!player.connected);
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -27,7 +27,7 @@ use std::{
 };
 use tokio::{
     net::TcpListener,
-    sync::{mpsc, Mutex},
+    sync::{mpsc, watch, Mutex},
     time::{self, Duration},
 };
 use tower_http::{
@@ -48,10 +48,31 @@ struct AppInner {
     connections: HashMap<String, Connection>,
 }
 
+const OUTBOUND_QUEUE_CAPACITY: usize = 16;
+
 struct Connection {
+    id: Uuid,
     role: Role,
     room_code: Option<String>,
-    tx: mpsc::UnboundedSender<ServerMessage>,
+    tx: mpsc::Sender<ServerMessage>,
+    close_tx: watch::Sender<bool>,
+}
+
+#[derive(Clone)]
+struct OutboundTarget {
+    tx: mpsc::Sender<ServerMessage>,
+    close_tx: watch::Sender<bool>,
+}
+
+type OutboundMessage = (OutboundTarget, ServerMessage);
+
+impl Connection {
+    fn outbound(&self) -> OutboundTarget {
+        OutboundTarget {
+            tx: self.tx.clone(),
+            close_tx: self.close_tx.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -221,19 +242,26 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
         .client_id
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| Uuid::new_v4().to_string());
+    let connection_id = Uuid::new_v4();
     let (mut ws_sender, mut ws_receiver) = socket.split();
-    let (tx, mut rx) = mpsc::unbounded_channel::<ServerMessage>();
+    let (tx, mut rx) = mpsc::channel::<ServerMessage>(OUTBOUND_QUEUE_CAPACITY);
+    let (close_tx, mut close_rx) = watch::channel(false);
+    let mut receiver_close_rx = close_rx.clone();
 
     {
         let mut inner = state.inner.lock().await;
-        inner.connections.insert(
+        if let Some(replaced) = inner.connections.insert(
             client_id.clone(),
             Connection {
+                id: connection_id,
                 role: query.role.clone(),
                 room_code: None,
                 tx,
+                close_tx,
             },
-        );
+        ) {
+            let _ = replaced.close_tx.send(true);
+        }
 
         if let Some(room_code) = &query.room {
             let room_code = room_code.to_uppercase();
@@ -267,87 +295,139 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
     }
 
     let sender_task = tokio::spawn(async move {
-        while let Some(message) = rx.recv().await {
-            match serde_json::to_string(&message) {
-                Ok(text) => {
-                    if ws_sender.send(Message::Text(text.into())).await.is_err() {
+        loop {
+            tokio::select! {
+                changed = close_rx.changed() => {
+                    if changed.is_err() || *close_rx.borrow() {
+                        let _ = ws_sender.send(Message::Close(None)).await;
                         break;
                     }
                 }
-                Err(err) => {
-                    error!(?err, "failed to serialize server message");
-                    break;
+                message = rx.recv() => {
+                    let Some(message) = message else {
+                        break;
+                    };
+                    match serde_json::to_string(&message) {
+                        Ok(text) => {
+                            tokio::select! {
+                                changed = close_rx.changed() => {
+                                    if changed.is_err() || *close_rx.borrow() {
+                                        let _ = ws_sender.send(Message::Close(None)).await;
+                                        break;
+                                    }
+                                }
+                                result = ws_sender.send(Message::Text(text.into())) => {
+                                    if result.is_err() {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            error!(?err, "failed to serialize server message");
+                            break;
+                        }
+                    }
                 }
             }
         }
     });
 
-    while let Some(message) = ws_receiver.next().await {
-        match message {
-            Ok(Message::Text(text)) => match serde_json::from_str::<ClientMessage>(text.as_str()) {
-                Ok(client_message) => {
-                    handle_client_message(&state, &client_id, client_message).await;
+    loop {
+        tokio::select! {
+            changed = receiver_close_rx.changed() => {
+                if changed.is_err() || *receiver_close_rx.borrow() {
+                    break;
                 }
-                Err(err) => {
-                    warn!(?err, "invalid client message");
-                    send_error(
-                        &state,
-                        &client_id,
-                        "invalid_message",
-                        "Message format was not understood.",
-                    )
-                    .await;
+            }
+            message = ws_receiver.next() => {
+                let Some(message) = message else {
+                    break;
+                };
+                match message {
+                    Ok(Message::Text(text)) => match serde_json::from_str::<ClientMessage>(text.as_str()) {
+                        Ok(client_message) => {
+                            handle_client_message(&state, &client_id, connection_id, client_message).await;
+                        }
+                        Err(err) => {
+                            warn!(?err, "invalid client message");
+                            send_error(
+                                &state,
+                                &client_id,
+                                connection_id,
+                                "invalid_message",
+                                "Message format was not understood.",
+                            )
+                            .await;
+                        }
+                    },
+                    Ok(Message::Close(_)) => break,
+                    Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Binary(_)) => {}
+                    Err(err) => {
+                        warn!(?err, "websocket receive error");
+                        break;
+                    }
                 }
-            },
-            Ok(Message::Close(_)) => break,
-            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) | Ok(Message::Binary(_)) => {}
-            Err(err) => {
-                warn!(?err, "websocket receive error");
-                break;
             }
         }
     }
 
     sender_task.abort();
-    disconnect_client(&state, &client_id).await;
+    disconnect_client(&state, &client_id, connection_id).await;
 }
 
-async fn handle_client_message(state: &AppState, client_id: &str, message: ClientMessage) {
+async fn handle_client_message(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    message: ClientMessage,
+) {
     match message {
-        ClientMessage::CreateRoom => create_room(state, client_id).await,
+        ClientMessage::CreateRoom => create_room(state, client_id, connection_id).await,
         ClientMessage::JoinRoom { room_code, name } => {
-            join_room(state, client_id, room_code, name).await
+            join_room(state, client_id, connection_id, room_code, name).await
         }
-        ClientMessage::SetName { name } => set_name(state, client_id, name).await,
+        ClientMessage::SetName { name } => set_name(state, client_id, connection_id, name).await,
         ClientMessage::UpdateRoomSettings { settings } => {
-            update_room_settings(state, client_id, settings).await
+            update_room_settings(state, client_id, connection_id, settings).await
         }
-        ClientMessage::StartGame => start_or_advance(state, client_id).await,
+        ClientMessage::StartGame => start_or_advance(state, client_id, connection_id).await,
         ClientMessage::SubmitDrawing {
             turn_token,
             drawing,
-        } => submit_drawing(state, client_id, turn_token, drawing).await,
+        } => submit_drawing(state, client_id, connection_id, turn_token, drawing).await,
         ClientMessage::SubmitGuess { turn_token, guess } => {
-            submit_guess(state, client_id, turn_token, guess).await
+            submit_guess(state, client_id, connection_id, turn_token, guess).await
         }
         ClientMessage::SubmitVote {
             turn_token,
             option_id,
-        } => submit_vote(state, client_id, turn_token, option_id).await,
-        ClientMessage::SendReaction { emoji } => send_reaction(state, client_id, emoji).await,
-        ClientMessage::Heartbeat => {
-            send_to_client(state, client_id, ServerMessage::Pong { now_ms: now_ms() }).await
+        } => submit_vote(state, client_id, connection_id, turn_token, option_id).await,
+        ClientMessage::SendReaction { emoji } => {
+            send_reaction(state, client_id, connection_id, emoji).await
         }
-        ClientMessage::LeaveRoom => disconnect_client(state, client_id).await,
+        ClientMessage::Heartbeat => {
+            send_to_client(
+                state,
+                client_id,
+                connection_id,
+                ServerMessage::Pong { now_ms: now_ms() },
+            )
+            .await
+        }
+        ClientMessage::LeaveRoom => disconnect_client(state, client_id, connection_id).await,
     }
 }
 
-async fn send_reaction(state: &AppState, client_id: &str, emoji: String) {
-    let messages = {
+async fn send_reaction(state: &AppState, client_id: &str, connection_id: Uuid, emoji: String) {
+    {
         let mut inner = state.inner.lock().await;
         let Some(conn) = inner.connections.get(client_id) else {
             return;
         };
+        if conn.id != connection_id {
+            return;
+        }
         if conn.role != Role::Player {
             return;
         }
@@ -357,7 +437,7 @@ async fn send_reaction(state: &AppState, client_id: &str, emoji: String) {
         let Some(room) = inner.rooms.get_mut(&room_code) else {
             return;
         };
-        match room.submit_reaction(client_id, &emoji, now_ms()) {
+        let messages = match room.submit_reaction(client_id, &emoji, now_ms()) {
             Ok(Some(burst)) => {
                 let mut out = Vec::new();
                 for (other_id, other_conn) in &inner.connections {
@@ -366,7 +446,7 @@ async fn send_reaction(state: &AppState, client_id: &str, emoji: String) {
                     }
                     let _ = other_id;
                     out.push((
-                        other_conn.tx.clone(),
+                        other_conn.outbound(),
                         ServerMessage::ReactionBurst {
                             player_id: burst.player_id.clone(),
                             name: burst.name.clone(),
@@ -378,22 +458,27 @@ async fn send_reaction(state: &AppState, client_id: &str, emoji: String) {
                 out
             }
             Ok(None) => Vec::new(),
-            Err(err) => targeted_error(&inner, client_id, err.code, &err.message),
-        }
-    };
-    send_many(messages);
+            Err(err) => targeted_error(&inner, client_id, connection_id, err.code, &err.message),
+        };
+        send_many(messages);
+    }
 }
 
-async fn create_room(state: &AppState, client_id: &str) {
-    let messages = {
+async fn create_room(state: &AppState, client_id: &str, connection_id: Uuid) {
+    {
         let mut inner = state.inner.lock().await;
-        if !matches!(
-            inner.connections.get(client_id).map(|conn| &conn.role),
+        let messages = if !matches!(
+            inner
+                .connections
+                .get(client_id)
+                .filter(|conn| conn.id == connection_id)
+                .map(|conn| &conn.role),
             Some(Role::Display)
         ) {
             targeted_error(
                 &inner,
                 client_id,
+                connection_id,
                 "display_only",
                 "Only the TV display can create rooms.",
             )
@@ -418,7 +503,7 @@ async fn create_room(state: &AppState, client_id: &str) {
                 .get(client_id)
                 .map(|conn| {
                     vec![(
-                        conn.tx.clone(),
+                        conn.outbound(),
                         ServerMessage::RoomCreated {
                             snapshot,
                             host_token,
@@ -426,57 +511,72 @@ async fn create_room(state: &AppState, client_id: &str) {
                     )]
                 })
                 .unwrap_or_default()
-        }
-    };
-    send_many(messages);
+        };
+        send_many(messages);
+    }
 }
 
-async fn join_room(state: &AppState, client_id: &str, room_code: String, name: String) {
+async fn join_room(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    room_code: String,
+    name: String,
+) {
     let room_code = room_code.to_uppercase();
-    mutate_room(state, client_id, &room_code, |room| {
+    mutate_room(state, client_id, connection_id, &room_code, |room| {
         room.upsert_player(client_id.to_string(), name, now_ms())?;
         Ok(EngineEvent::PlayerListChanged)
     })
     .await;
 }
 
-async fn set_name(state: &AppState, client_id: &str, name: String) {
-    mutate_current_room(state, client_id, |room| {
+async fn set_name(state: &AppState, client_id: &str, connection_id: Uuid, name: String) {
+    mutate_current_room(state, client_id, connection_id, |room| {
         room.set_name(client_id, name, now_ms())?;
         Ok(EngineEvent::PlayerListChanged)
     })
     .await;
 }
 
-async fn update_room_settings(state: &AppState, client_id: &str, settings: RoomSettings) {
-    let Some(room_code) = authorized_controller_room_code(state, client_id).await else {
+async fn update_room_settings(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    settings: RoomSettings,
+) {
+    let Some(room_code) = authorized_controller_room_code(state, client_id, connection_id).await
+    else {
         send_error(
             state,
             client_id,
+            connection_id,
             "not_authorized",
             "Only the TV display or the host phone can change room settings.",
         )
         .await;
         return;
     };
-    mutate_room(state, client_id, &room_code, |room| {
+    mutate_room(state, client_id, connection_id, &room_code, |room| {
         room.update_settings(settings, now_ms())
     })
     .await;
 }
 
-async fn start_or_advance(state: &AppState, client_id: &str) {
-    let Some(room_code) = authorized_controller_room_code(state, client_id).await else {
+async fn start_or_advance(state: &AppState, client_id: &str, connection_id: Uuid) {
+    let Some(room_code) = authorized_controller_room_code(state, client_id, connection_id).await
+    else {
         send_error(
             state,
             client_id,
+            connection_id,
             "not_authorized",
             "Only the TV display or the host phone can advance the game.",
         )
         .await;
         return;
     };
-    mutate_room(state, client_id, &room_code, |room| {
+    mutate_room(state, client_id, connection_id, &room_code, |room| {
         room.handle_start_or_advance(now_ms())
     })
     .await;
@@ -485,31 +585,48 @@ async fn start_or_advance(state: &AppState, client_id: &str) {
 async fn submit_drawing(
     state: &AppState,
     client_id: &str,
+    connection_id: Uuid,
     turn_token: u64,
     drawing: draw_party_server::protocol::DrawingDoc,
 ) {
-    mutate_current_room(state, client_id, |room| {
+    mutate_current_room(state, client_id, connection_id, |room| {
         room.submit_drawing(client_id, turn_token, drawing, now_ms())
     })
     .await;
 }
 
-async fn submit_guess(state: &AppState, client_id: &str, turn_token: u64, guess: String) {
-    mutate_current_room(state, client_id, |room| {
+async fn submit_guess(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    turn_token: u64,
+    guess: String,
+) {
+    mutate_current_room(state, client_id, connection_id, |room| {
         room.submit_guess(client_id, turn_token, guess, now_ms())
     })
     .await;
 }
 
-async fn submit_vote(state: &AppState, client_id: &str, turn_token: u64, option_id: String) {
-    mutate_current_room(state, client_id, |room| {
+async fn submit_vote(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    turn_token: u64,
+    option_id: String,
+) {
+    mutate_current_room(state, client_id, connection_id, |room| {
         room.submit_vote(client_id, turn_token, option_id, now_ms())
     })
     .await;
 }
 
-async fn mutate_current_room<F>(state: &AppState, client_id: &str, operation: F)
-where
+async fn mutate_current_room<F>(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    operation: F,
+) where
     F: FnOnce(&mut Room) -> Result<EngineEvent, EngineError>,
 {
     let room_code = {
@@ -517,22 +634,42 @@ where
         inner
             .connections
             .get(client_id)
+            .filter(|conn| conn.id == connection_id)
             .and_then(|conn| conn.room_code.clone())
     };
 
     if let Some(room_code) = room_code {
-        mutate_room(state, client_id, &room_code, operation).await;
+        mutate_room(state, client_id, connection_id, &room_code, operation).await;
     } else {
-        send_error(state, client_id, "not_in_room", "Join a room first.").await;
+        send_error(
+            state,
+            client_id,
+            connection_id,
+            "not_in_room",
+            "Join a room first.",
+        )
+        .await;
     }
 }
 
-async fn mutate_room<F>(state: &AppState, client_id: &str, room_code: &str, operation: F)
-where
+async fn mutate_room<F>(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    room_code: &str,
+    operation: F,
+) where
     F: FnOnce(&mut Room) -> Result<EngineEvent, EngineError>,
 {
-    let messages = {
+    {
         let mut inner = state.inner.lock().await;
+        if inner
+            .connections
+            .get(client_id)
+            .is_none_or(|conn| conn.id != connection_id)
+        {
+            return;
+        }
         let result = inner
             .rooms
             .get_mut(room_code)
@@ -544,27 +681,36 @@ where
                 })
             });
 
-        match result {
+        let messages = match result {
             Ok(event) => {
                 if let Some(conn) = inner.connections.get_mut(client_id) {
                     conn.room_code = Some(room_code.to_string());
                 }
                 room_messages(&inner, room_code, event)
             }
-            Err(error) => targeted_error(&inner, client_id, error.code, &error.message),
-        }
-    };
-    send_many(messages);
+            Err(error) => {
+                targeted_error(&inner, client_id, connection_id, error.code, &error.message)
+            }
+        };
+        send_many(messages);
+    }
 }
 
-async fn disconnect_client(state: &AppState, client_id: &str) {
-    let messages = {
+async fn disconnect_client(state: &AppState, client_id: &str, connection_id: Uuid) {
+    {
         let mut inner = state.inner.lock().await;
+        if inner
+            .connections
+            .get(client_id)
+            .is_none_or(|conn| conn.id != connection_id)
+        {
+            return;
+        }
         let room_code = inner
             .connections
             .remove(client_id)
             .and_then(|conn| conn.room_code);
-        if let Some(room_code) = room_code {
+        let messages = if let Some(room_code) = room_code {
             let event = if let Some(room) = inner.rooms.get_mut(&room_code) {
                 let now = now_ms();
                 room.mark_disconnected(client_id, now);
@@ -590,9 +736,9 @@ async fn disconnect_client(state: &AppState, client_id: &str) {
                 .unwrap_or_default()
         } else {
             Vec::new()
-        }
-    };
-    send_many(messages);
+        };
+        send_many(messages);
+    }
 }
 
 fn spawn_room_maintenance(state: AppState) {
@@ -600,7 +746,7 @@ fn spawn_room_maintenance(state: AppState) {
         let mut interval = time::interval(Duration::from_secs(1));
         loop {
             interval.tick().await;
-            let messages = {
+            {
                 let mut inner = state.inner.lock().await;
                 let now = now_ms();
                 let mut changed_rooms = Vec::new();
@@ -631,21 +777,17 @@ fn spawn_room_maintenance(state: AppState) {
                     inner.rooms.remove(&room_code);
                 }
 
-                changed_rooms
+                let messages = changed_rooms
                     .into_iter()
                     .flat_map(|(room_code, event)| room_messages(&inner, &room_code, event))
-                    .collect::<Vec<_>>()
-            };
-            send_many(messages);
+                    .collect::<Vec<_>>();
+                send_many(messages);
+            }
         }
     });
 }
 
-fn room_messages(
-    inner: &AppInner,
-    room_code: &str,
-    event: EngineEvent,
-) -> Vec<(mpsc::UnboundedSender<ServerMessage>, ServerMessage)> {
+fn room_messages(inner: &AppInner, room_code: &str, event: EngineEvent) -> Vec<OutboundMessage> {
     let Some(room) = inner.rooms.get(room_code) else {
         return Vec::new();
     };
@@ -671,9 +813,9 @@ fn room_messages(
                 snapshot: snapshot.clone(),
             },
         };
-        messages.push((conn.tx.clone(), event_message));
+        messages.push((conn.outbound(), event_message));
         messages.push((
-            conn.tx.clone(),
+            conn.outbound(),
             ServerMessage::RoomSnapshot {
                 snapshot: snapshot.clone(),
             },
@@ -681,7 +823,7 @@ fn room_messages(
 
         if snapshot.phase == GamePhase::Drawing && conn.role == Role::Player {
             if let Some(prompt) = room.prompt_for_player(client_id) {
-                messages.push((conn.tx.clone(), ServerMessage::PromptAssigned { prompt }));
+                messages.push((conn.outbound(), ServerMessage::PromptAssigned { prompt }));
             }
         }
 
@@ -692,7 +834,7 @@ fn room_messages(
                 snapshot.current_drawing.clone(),
             ) {
                 messages.push((
-                    conn.tx.clone(),
+                    conn.outbound(),
                     ServerMessage::DrawingReveal {
                         artist_id,
                         artist_name,
@@ -704,7 +846,7 @@ fn room_messages(
 
         if snapshot.phase == GamePhase::Voting {
             messages.push((
-                conn.tx.clone(),
+                conn.outbound(),
                 ServerMessage::VotingOptions {
                     options: snapshot.voting_options.clone(),
                 },
@@ -713,7 +855,7 @@ fn room_messages(
 
         if snapshot.phase == GamePhase::Results {
             if let Some(result) = snapshot.round_result.clone() {
-                messages.push((conn.tx.clone(), ServerMessage::RoundResult { result }));
+                messages.push((conn.outbound(), ServerMessage::RoundResult { result }));
             }
         }
     }
@@ -749,23 +891,36 @@ fn personalize_snapshot(
 
 fn queue_snapshot_for_connection(inner: &AppInner, client_id: &str, snapshot: RoomSnapshot) {
     if let Some(conn) = inner.connections.get(client_id) {
-        let _ = conn.tx.send(ServerMessage::RoomSnapshot { snapshot });
+        send_many(vec![(
+            conn.outbound(),
+            ServerMessage::RoomSnapshot { snapshot },
+        )]);
     }
 }
 
 fn queue_error_for_connection(inner: &AppInner, client_id: &str, err: EngineError) {
     if let Some(conn) = inner.connections.get(client_id) {
-        let _ = conn.tx.send(ServerMessage::Error {
-            code: err.code.to_string(),
-            message: err.message,
-        });
+        send_many(vec![(
+            conn.outbound(),
+            ServerMessage::Error {
+                code: err.code.to_string(),
+                message: err.message,
+            },
+        )]);
     }
 }
 
-async fn send_error(state: &AppState, client_id: &str, code: &str, message: &str) {
+async fn send_error(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    code: &str,
+    message: &str,
+) {
     send_to_client(
         state,
         client_id,
+        connection_id,
         ServerMessage::Error {
             code: code.to_string(),
             message: message.to_string(),
@@ -774,28 +929,38 @@ async fn send_error(state: &AppState, client_id: &str, code: &str, message: &str
     .await;
 }
 
-async fn send_to_client(state: &AppState, client_id: &str, message: ServerMessage) {
-    let tx = {
+async fn send_to_client(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+    message: ServerMessage,
+) {
+    {
         let inner = state.inner.lock().await;
-        inner.connections.get(client_id).map(|conn| conn.tx.clone())
-    };
-    if let Some(tx) = tx {
-        let _ = tx.send(message);
+        if let Some(conn) = inner
+            .connections
+            .get(client_id)
+            .filter(|conn| conn.id == connection_id)
+        {
+            send_many(vec![(conn.outbound(), message)]);
+        }
     }
 }
 
 fn targeted_error(
     inner: &AppInner,
     client_id: &str,
+    connection_id: Uuid,
     code: &str,
     message: &str,
-) -> Vec<(mpsc::UnboundedSender<ServerMessage>, ServerMessage)> {
+) -> Vec<OutboundMessage> {
     inner
         .connections
         .get(client_id)
+        .filter(|conn| conn.id == connection_id)
         .map(|conn| {
             vec![(
-                conn.tx.clone(),
+                conn.outbound(),
                 ServerMessage::Error {
                     code: code.to_string(),
                     message: message.to_string(),
@@ -805,15 +970,24 @@ fn targeted_error(
         .unwrap_or_default()
 }
 
-fn send_many(messages: Vec<(mpsc::UnboundedSender<ServerMessage>, ServerMessage)>) {
-    for (tx, message) in messages {
-        let _ = tx.send(message);
+fn send_many(messages: Vec<OutboundMessage>) {
+    for (target, message) in messages {
+        if target.tx.try_send(message).is_err() {
+            let _ = target.close_tx.send(true);
+        }
     }
 }
 
-async fn authorized_controller_room_code(state: &AppState, client_id: &str) -> Option<String> {
+async fn authorized_controller_room_code(
+    state: &AppState,
+    client_id: &str,
+    connection_id: Uuid,
+) -> Option<String> {
     let inner = state.inner.lock().await;
     let conn = inner.connections.get(client_id)?;
+    if conn.id != connection_id {
+        return None;
+    }
     let room_code = conn.room_code.as_ref()?;
     let room = inner.rooms.get(room_code)?;
     match conn.role {
@@ -973,6 +1147,88 @@ mod tests {
                 .is_err(),
             "unexpected websocket message was received"
         );
+    }
+
+    #[tokio::test]
+    async fn outbound_backpressure_retires_only_the_slow_connection() {
+        let (slow_tx, mut slow_rx) = mpsc::channel(1);
+        let (slow_close_tx, mut slow_close_rx) = watch::channel(false);
+        let slow_target = OutboundTarget {
+            tx: slow_tx,
+            close_tx: slow_close_tx,
+        };
+
+        let (healthy_tx, mut healthy_rx) = mpsc::channel(2);
+        let (healthy_close_tx, healthy_close_rx) = watch::channel(false);
+        let healthy_target = OutboundTarget {
+            tx: healthy_tx,
+            close_tx: healthy_close_tx,
+        };
+
+        send_many(vec![
+            (slow_target.clone(), ServerMessage::Pong { now_ms: 1 }),
+            (slow_target, ServerMessage::Pong { now_ms: 2 }),
+            (healthy_target, ServerMessage::Pong { now_ms: 3 }),
+        ]);
+
+        assert!(matches!(
+            slow_rx.try_recv(),
+            Ok(ServerMessage::Pong { now_ms: 1 })
+        ));
+        slow_close_rx.changed().await.unwrap();
+        assert!(*slow_close_rx.borrow());
+        assert!(matches!(
+            healthy_rx.try_recv(),
+            Ok(ServerMessage::Pong { now_ms: 3 })
+        ));
+        assert!(!*healthy_close_rx.borrow());
+    }
+
+    #[tokio::test]
+    async fn retiring_the_current_connection_marks_its_player_disconnected() {
+        let room_code = "ABCD".to_string();
+        let client_id = "slow-player".to_string();
+        let connection_id = Uuid::new_v4();
+        let now = now_ms();
+        let mut room = Room::new(
+            room_code.clone(),
+            "display".to_string(),
+            "host-token".to_string(),
+            now,
+        );
+        room.upsert_player(client_id.clone(), "Ada".to_string(), now)
+            .unwrap();
+        let (tx, _rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+        let (close_tx, _close_rx) = watch::channel(false);
+        let state = AppState {
+            inner: Arc::new(Mutex::new(AppInner {
+                rooms: HashMap::from([(room_code.clone(), room)]),
+                connections: HashMap::from([(
+                    client_id.clone(),
+                    Connection {
+                        id: connection_id,
+                        role: Role::Player,
+                        room_code: Some(room_code.clone()),
+                        tx,
+                        close_tx,
+                    },
+                )]),
+            })),
+        };
+
+        disconnect_client(&state, &client_id, connection_id).await;
+
+        let inner = state.inner.lock().await;
+        let snapshot = inner.rooms.get(&room_code).unwrap().snapshot(now_ms());
+        assert_eq!(
+            snapshot
+                .players
+                .iter()
+                .find(|player| player.id == client_id)
+                .map(|player| player.connected),
+            Some(false)
+        );
+        assert!(!inner.connections.contains_key(&client_id));
     }
 
     #[test]
@@ -1209,6 +1465,46 @@ mod tests {
             Some("drawing")
         );
         expect_no_message(&mut unauthorized).await;
+    }
+
+    #[tokio::test]
+    async fn websocket_replacement_closes_the_superseded_connection() {
+        let url = spawn_ws_server().await;
+        let (mut original, _) = connect_async(format!("{url}?role=display&clientId=display"))
+            .await
+            .unwrap();
+        let (room_code, host_token, _) = create_test_room(&mut original).await;
+
+        let (mut replacement, _) = connect_async(format!(
+            "{url}?role=display&room={room_code}&hostToken={host_token}&clientId=display"
+        ))
+        .await
+        .unwrap();
+        let snapshot = read_until_type(&mut replacement, "roomSnapshot").await;
+        assert_eq!(
+            snapshot
+                .pointer("/snapshot/roomCode")
+                .and_then(Value::as_str),
+            Some(room_code.as_str())
+        );
+
+        let closed = time::timeout(Duration::from_secs(1), original.next())
+            .await
+            .expect("superseded socket did not terminate");
+        assert!(matches!(
+            closed,
+            Some(Ok(WsMessage::Close(_))) | Some(Err(_)) | None
+        ));
+
+        replacement
+            .send(text_message(json!({ "type": "heartbeat" })))
+            .await
+            .unwrap();
+        assert!(read_until_type(&mut replacement, "pong")
+            .await
+            .get("nowMs")
+            .and_then(Value::as_u64)
+            .is_some());
     }
 
     #[tokio::test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,6 +12,8 @@ use axum::{
     routing::get,
     Json, Router,
 };
+mod session;
+
 use draw_party_server::{
     engine::{generate_room_code, EngineError, EngineEvent, Room},
     protocol::{ClientMessage, GamePhase, Role, RoomSettings, RoomSnapshot, ServerMessage},
@@ -27,7 +29,7 @@ use std::{
 };
 use tokio::{
     net::TcpListener,
-    sync::{mpsc, watch, Mutex},
+    sync::Mutex,
     time::{self, Duration},
 };
 use tower_http::{
@@ -36,6 +38,8 @@ use tower_http::{
 };
 use tracing::{error, info, warn};
 use uuid::Uuid;
+
+use session::{deliver_many, Connection, OutboundMessage, SessionKey};
 
 #[derive(Clone)]
 struct AppState {
@@ -48,29 +52,29 @@ struct AppInner {
     connections: HashMap<String, Connection>,
 }
 
-const OUTBOUND_QUEUE_CAPACITY: usize = 16;
+impl AppInner {
+    fn connection(&self, session: &SessionKey) -> Option<&Connection> {
+        self.connections
+            .get(session.client_id())
+            .filter(|connection| connection.matches(session))
+    }
 
-struct Connection {
-    id: Uuid,
-    role: Role,
-    room_code: Option<String>,
-    tx: mpsc::Sender<ServerMessage>,
-    close_tx: watch::Sender<bool>,
-}
+    fn connection_mut(&mut self, session: &SessionKey) -> Option<&mut Connection> {
+        self.connections
+            .get_mut(session.client_id())
+            .filter(|connection| connection.matches(session))
+    }
 
-#[derive(Clone)]
-struct OutboundTarget {
-    tx: mpsc::Sender<ServerMessage>,
-    close_tx: watch::Sender<bool>,
-}
+    fn replace_connection(&mut self, connection: Connection) -> Option<Connection> {
+        self.connections
+            .insert(connection.key().client_id().to_string(), connection)
+    }
 
-type OutboundMessage = (OutboundTarget, ServerMessage);
-
-impl Connection {
-    fn outbound(&self) -> OutboundTarget {
-        OutboundTarget {
-            tx: self.tx.clone(),
-            close_tx: self.close_tx.clone(),
+    fn remove_connection(&mut self, session: &SessionKey) -> Option<Connection> {
+        if self.connection(session).is_some() {
+            self.connections.remove(session.client_id())
+        } else {
+            None
         }
     }
 }
@@ -82,6 +86,7 @@ struct WsQuery {
     role: Role,
     #[serde(alias = "client_id")]
     client_id: Option<String>,
+    session_token: Option<String>,
     host_token: Option<String>,
 }
 
@@ -242,56 +247,74 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
         .client_id
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| Uuid::new_v4().to_string());
-    let connection_id = Uuid::new_v4();
+    let session_token = query
+        .session_token
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
     let (mut ws_sender, mut ws_receiver) = socket.split();
-    let (tx, mut rx) = mpsc::channel::<ServerMessage>(OUTBOUND_QUEUE_CAPACITY);
-    let (close_tx, mut close_rx) = watch::channel(false);
+    let (connection, mut rx, mut close_rx) =
+        Connection::new(client_id.clone(), query.role.clone(), session_token.clone());
+    let session = connection.key().clone();
     let mut receiver_close_rx = close_rx.clone();
 
-    {
+    let rejected = {
         let mut inner = state.inner.lock().await;
-        if let Some(replaced) = inner.connections.insert(
-            client_id.clone(),
-            Connection {
-                id: connection_id,
-                role: query.role.clone(),
-                room_code: None,
-                tx,
-                close_tx,
-            },
-        ) {
-            let _ = replaced.close_tx.send(true);
-        }
+        if inner
+            .connections
+            .get(&client_id)
+            .is_some_and(|existing| !existing.accepts_session_token(&session_token))
+        {
+            true
+        } else {
+            if let Some(replaced) = inner.replace_connection(connection) {
+                replaced.retire();
+            }
 
-        if let Some(room_code) = &query.room {
-            let room_code = room_code.to_uppercase();
-            if query.role == Role::Display {
-                let now = now_ms();
-                let snapshot = match inner.rooms.get_mut(&room_code) {
-                    Some(room) if query.host_token.as_deref() == Some(room.host_token.as_str()) => {
-                        room.add_display(client_id.clone(), now);
-                        Ok(room.snapshot(now))
-                    }
-                    Some(_) => Err(EngineError {
-                        code: "unauthorized_display",
-                        message: "This display is not authorized for that room.".to_string(),
-                    }),
-                    None => Err(EngineError {
-                        code: "room_not_found",
-                        message: "That room does not exist.".to_string(),
-                    }),
-                };
-                match snapshot {
-                    Ok(snapshot) => {
-                        if let Some(conn) = inner.connections.get_mut(&client_id) {
-                            conn.room_code = Some(room_code.clone());
+            if let Some(room_code) = &query.room {
+                let room_code = room_code.to_uppercase();
+                if query.role == Role::Display {
+                    let now = now_ms();
+                    let snapshot = match inner.rooms.get_mut(&room_code) {
+                        Some(room)
+                            if query.host_token.as_deref() == Some(room.host_token.as_str()) =>
+                        {
+                            room.add_display(client_id.clone(), now);
+                            Ok(room.snapshot(now))
                         }
-                        queue_snapshot_for_connection(&inner, &client_id, snapshot);
+                        Some(_) => Err(EngineError {
+                            code: "unauthorized_display",
+                            message: "This display is not authorized for that room.".to_string(),
+                        }),
+                        None => Err(EngineError {
+                            code: "room_not_found",
+                            message: "That room does not exist.".to_string(),
+                        }),
+                    };
+                    match snapshot {
+                        Ok(snapshot) => {
+                            if let Some(conn) = inner.connection_mut(&session) {
+                                conn.set_room_code(room_code.clone());
+                            }
+                            queue_snapshot_for_connection(&inner, &session, snapshot);
+                        }
+                        Err(err) => queue_error_for_connection(&inner, &session, err),
                     }
-                    Err(err) => queue_error_for_connection(&inner, &client_id, err),
                 }
             }
+            false
         }
+    };
+
+    if rejected {
+        let error = ServerMessage::Error {
+            code: "session_in_use".to_string(),
+            message: "This player session is already active on another device.".to_string(),
+        };
+        if let Ok(text) = serde_json::to_string(&error) {
+            let _ = ws_sender.send(Message::Text(text.into())).await;
+        }
+        let _ = ws_sender.send(Message::Close(None)).await;
+        return;
     }
 
     let sender_task = tokio::spawn(async move {
@@ -347,14 +370,13 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
                 match message {
                     Ok(Message::Text(text)) => match serde_json::from_str::<ClientMessage>(text.as_str()) {
                         Ok(client_message) => {
-                            handle_client_message(&state, &client_id, connection_id, client_message).await;
+                            handle_client_message(&state, &session, client_message).await;
                         }
                         Err(err) => {
                             warn!(?err, "invalid client message");
                             send_error(
                                 &state,
-                                &client_id,
-                                connection_id,
+                                &session,
                                 "invalid_message",
                                 "Message format was not understood.",
                             )
@@ -373,75 +395,59 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
     }
 
     sender_task.abort();
-    disconnect_client(&state, &client_id, connection_id).await;
+    disconnect_client(&state, &session).await;
 }
 
-async fn handle_client_message(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    message: ClientMessage,
-) {
+async fn handle_client_message(state: &AppState, session: &SessionKey, message: ClientMessage) {
     match message {
-        ClientMessage::CreateRoom => create_room(state, client_id, connection_id).await,
+        ClientMessage::CreateRoom => create_room(state, session).await,
         ClientMessage::JoinRoom { room_code, name } => {
-            join_room(state, client_id, connection_id, room_code, name).await
+            join_room(state, session, room_code, name).await
         }
-        ClientMessage::SetName { name } => set_name(state, client_id, connection_id, name).await,
+        ClientMessage::SetName { name } => set_name(state, session, name).await,
         ClientMessage::UpdateRoomSettings { settings } => {
-            update_room_settings(state, client_id, connection_id, settings).await
+            update_room_settings(state, session, settings).await
         }
-        ClientMessage::StartGame => start_or_advance(state, client_id, connection_id).await,
+        ClientMessage::StartGame => start_or_advance(state, session).await,
         ClientMessage::SubmitDrawing {
             turn_token,
             drawing,
-        } => submit_drawing(state, client_id, connection_id, turn_token, drawing).await,
+        } => submit_drawing(state, session, turn_token, drawing).await,
         ClientMessage::SubmitGuess { turn_token, guess } => {
-            submit_guess(state, client_id, connection_id, turn_token, guess).await
+            submit_guess(state, session, turn_token, guess).await
         }
         ClientMessage::SubmitVote {
             turn_token,
             option_id,
-        } => submit_vote(state, client_id, connection_id, turn_token, option_id).await,
-        ClientMessage::SendReaction { emoji } => {
-            send_reaction(state, client_id, connection_id, emoji).await
-        }
+        } => submit_vote(state, session, turn_token, option_id).await,
+        ClientMessage::SendReaction { emoji } => send_reaction(state, session, emoji).await,
         ClientMessage::Heartbeat => {
-            send_to_client(
-                state,
-                client_id,
-                connection_id,
-                ServerMessage::Pong { now_ms: now_ms() },
-            )
-            .await
+            send_to_client(state, session, ServerMessage::Pong { now_ms: now_ms() }).await
         }
-        ClientMessage::LeaveRoom => disconnect_client(state, client_id, connection_id).await,
+        ClientMessage::LeaveRoom => disconnect_client(state, session).await,
     }
 }
 
-async fn send_reaction(state: &AppState, client_id: &str, connection_id: Uuid, emoji: String) {
+async fn send_reaction(state: &AppState, session: &SessionKey, emoji: String) {
     {
         let mut inner = state.inner.lock().await;
-        let Some(conn) = inner.connections.get(client_id) else {
+        let Some(conn) = inner.connection(session) else {
             return;
         };
-        if conn.id != connection_id {
+        if conn.role() != &Role::Player {
             return;
         }
-        if conn.role != Role::Player {
-            return;
-        }
-        let Some(room_code) = conn.room_code.clone() else {
+        let Some(room_code) = conn.room_code_owned() else {
             return;
         };
         let Some(room) = inner.rooms.get_mut(&room_code) else {
             return;
         };
-        let messages = match room.submit_reaction(client_id, &emoji, now_ms()) {
+        let messages = match room.submit_reaction(session.client_id(), &emoji, now_ms()) {
             Ok(Some(burst)) => {
                 let mut out = Vec::new();
                 for (other_id, other_conn) in &inner.connections {
-                    if other_conn.room_code.as_deref() != Some(room_code.as_str()) {
+                    if other_conn.room_code() != Some(room_code.as_str()) {
                         continue;
                     }
                     let _ = other_id;
@@ -458,27 +464,22 @@ async fn send_reaction(state: &AppState, client_id: &str, connection_id: Uuid, e
                 out
             }
             Ok(None) => Vec::new(),
-            Err(err) => targeted_error(&inner, client_id, connection_id, err.code, &err.message),
+            Err(err) => targeted_error(&inner, session, err.code, &err.message),
         };
-        send_many(messages);
+        deliver_many(messages);
     }
 }
 
-async fn create_room(state: &AppState, client_id: &str, connection_id: Uuid) {
+async fn create_room(state: &AppState, session: &SessionKey) {
     {
         let mut inner = state.inner.lock().await;
         let messages = if !matches!(
-            inner
-                .connections
-                .get(client_id)
-                .filter(|conn| conn.id == connection_id)
-                .map(|conn| &conn.role),
+            inner.connection(session).map(Connection::role),
             Some(Role::Display)
         ) {
             targeted_error(
                 &inner,
-                client_id,
-                connection_id,
+                session,
                 "display_only",
                 "Only the TV display can create rooms.",
             )
@@ -489,18 +490,17 @@ async fn create_room(state: &AppState, client_id: &str, connection_id: Uuid) {
             let now = now_ms();
             let room = Room::new(
                 room_code.clone(),
-                client_id.to_string(),
+                session.client_id().to_string(),
                 host_token.clone(),
                 now,
             );
             let snapshot = room.snapshot(now);
             inner.rooms.insert(room_code.clone(), room);
-            if let Some(conn) = inner.connections.get_mut(client_id) {
-                conn.room_code = Some(room_code.clone());
+            if let Some(conn) = inner.connection_mut(session) {
+                conn.set_room_code(room_code.clone());
             }
             inner
-                .connections
-                .get(client_id)
+                .connection(session)
                 .map(|conn| {
                     vec![(
                         conn.outbound(),
@@ -512,71 +512,70 @@ async fn create_room(state: &AppState, client_id: &str, connection_id: Uuid) {
                 })
                 .unwrap_or_default()
         };
-        send_many(messages);
+        deliver_many(messages);
     }
 }
 
-async fn join_room(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    room_code: String,
-    name: String,
-) {
+async fn join_room(state: &AppState, session: &SessionKey, room_code: String, name: String) {
     let room_code = room_code.to_uppercase();
-    mutate_room(state, client_id, connection_id, &room_code, |room| {
-        room.upsert_player(client_id.to_string(), name, now_ms())?;
+    let session_token = {
+        let inner = state.inner.lock().await;
+        inner
+            .connection(session)
+            .map(|connection| connection.session_token().to_string())
+    };
+    let Some(session_token) = session_token else {
+        return;
+    };
+    mutate_room(state, session, &room_code, |room| {
+        room.upsert_player_with_session(
+            session.client_id().to_string(),
+            session_token,
+            name,
+            now_ms(),
+        )?;
         Ok(EngineEvent::PlayerListChanged)
     })
     .await;
 }
 
-async fn set_name(state: &AppState, client_id: &str, connection_id: Uuid, name: String) {
-    mutate_current_room(state, client_id, connection_id, |room| {
-        room.set_name(client_id, name, now_ms())?;
+async fn set_name(state: &AppState, session: &SessionKey, name: String) {
+    mutate_current_room(state, session, |room| {
+        room.set_name(session.client_id(), name, now_ms())?;
         Ok(EngineEvent::PlayerListChanged)
     })
     .await;
 }
 
-async fn update_room_settings(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    settings: RoomSettings,
-) {
-    let Some(room_code) = authorized_controller_room_code(state, client_id, connection_id).await
-    else {
+async fn update_room_settings(state: &AppState, session: &SessionKey, settings: RoomSettings) {
+    let Some(room_code) = authorized_controller_room_code(state, session).await else {
         send_error(
             state,
-            client_id,
-            connection_id,
+            session,
             "not_authorized",
             "Only the TV display or the host phone can change room settings.",
         )
         .await;
         return;
     };
-    mutate_room(state, client_id, connection_id, &room_code, |room| {
+    mutate_room(state, session, &room_code, |room| {
         room.update_settings(settings, now_ms())
     })
     .await;
 }
 
-async fn start_or_advance(state: &AppState, client_id: &str, connection_id: Uuid) {
-    let Some(room_code) = authorized_controller_room_code(state, client_id, connection_id).await
-    else {
+async fn start_or_advance(state: &AppState, session: &SessionKey) {
+    let Some(room_code) = authorized_controller_room_code(state, session).await else {
         send_error(
             state,
-            client_id,
-            connection_id,
+            session,
             "not_authorized",
             "Only the TV display or the host phone can advance the game.",
         )
         .await;
         return;
     };
-    mutate_room(state, client_id, connection_id, &room_code, |room| {
+    mutate_room(state, session, &room_code, |room| {
         room.handle_start_or_advance(now_ms())
     })
     .await;
@@ -584,90 +583,55 @@ async fn start_or_advance(state: &AppState, client_id: &str, connection_id: Uuid
 
 async fn submit_drawing(
     state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
+    session: &SessionKey,
     turn_token: u64,
     drawing: draw_party_server::protocol::DrawingDoc,
 ) {
-    mutate_current_room(state, client_id, connection_id, |room| {
-        room.submit_drawing(client_id, turn_token, drawing, now_ms())
+    mutate_current_room(state, session, |room| {
+        room.submit_drawing(session.client_id(), turn_token, drawing, now_ms())
     })
     .await;
 }
 
-async fn submit_guess(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    turn_token: u64,
-    guess: String,
-) {
-    mutate_current_room(state, client_id, connection_id, |room| {
-        room.submit_guess(client_id, turn_token, guess, now_ms())
+async fn submit_guess(state: &AppState, session: &SessionKey, turn_token: u64, guess: String) {
+    mutate_current_room(state, session, |room| {
+        room.submit_guess(session.client_id(), turn_token, guess, now_ms())
     })
     .await;
 }
 
-async fn submit_vote(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    turn_token: u64,
-    option_id: String,
-) {
-    mutate_current_room(state, client_id, connection_id, |room| {
-        room.submit_vote(client_id, turn_token, option_id, now_ms())
+async fn submit_vote(state: &AppState, session: &SessionKey, turn_token: u64, option_id: String) {
+    mutate_current_room(state, session, |room| {
+        room.submit_vote(session.client_id(), turn_token, option_id, now_ms())
     })
     .await;
 }
 
-async fn mutate_current_room<F>(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    operation: F,
-) where
+async fn mutate_current_room<F>(state: &AppState, session: &SessionKey, operation: F)
+where
     F: FnOnce(&mut Room) -> Result<EngineEvent, EngineError>,
 {
     let room_code = {
         let inner = state.inner.lock().await;
         inner
-            .connections
-            .get(client_id)
-            .filter(|conn| conn.id == connection_id)
-            .and_then(|conn| conn.room_code.clone())
+            .connection(session)
+            .and_then(Connection::room_code_owned)
     };
 
     if let Some(room_code) = room_code {
-        mutate_room(state, client_id, connection_id, &room_code, operation).await;
+        mutate_room(state, session, &room_code, operation).await;
     } else {
-        send_error(
-            state,
-            client_id,
-            connection_id,
-            "not_in_room",
-            "Join a room first.",
-        )
-        .await;
+        send_error(state, session, "not_in_room", "Join a room first.").await;
     }
 }
 
-async fn mutate_room<F>(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    room_code: &str,
-    operation: F,
-) where
+async fn mutate_room<F>(state: &AppState, session: &SessionKey, room_code: &str, operation: F)
+where
     F: FnOnce(&mut Room) -> Result<EngineEvent, EngineError>,
 {
     {
         let mut inner = state.inner.lock().await;
-        if inner
-            .connections
-            .get(client_id)
-            .is_none_or(|conn| conn.id != connection_id)
-        {
+        if inner.connection(session).is_none() {
             return;
         }
         let result = inner
@@ -683,44 +647,34 @@ async fn mutate_room<F>(
 
         let messages = match result {
             Ok(event) => {
-                if let Some(conn) = inner.connections.get_mut(client_id) {
-                    conn.room_code = Some(room_code.to_string());
+                if let Some(conn) = inner.connection_mut(session) {
+                    conn.set_room_code(room_code.to_string());
                 }
                 room_messages(&inner, room_code, event)
             }
-            Err(error) => {
-                targeted_error(&inner, client_id, connection_id, error.code, &error.message)
-            }
+            Err(error) => targeted_error(&inner, session, error.code, &error.message),
         };
-        send_many(messages);
+        deliver_many(messages);
     }
 }
 
-async fn disconnect_client(state: &AppState, client_id: &str, connection_id: Uuid) {
+async fn disconnect_client(state: &AppState, session: &SessionKey) {
     {
         let mut inner = state.inner.lock().await;
-        if inner
-            .connections
-            .get(client_id)
-            .is_none_or(|conn| conn.id != connection_id)
-        {
-            return;
-        }
         let room_code = inner
-            .connections
-            .remove(client_id)
-            .and_then(|conn| conn.room_code);
+            .remove_connection(session)
+            .and_then(|conn| conn.room_code_owned());
         let messages = if let Some(room_code) = room_code {
             let event = if let Some(room) = inner.rooms.get_mut(&room_code) {
                 let now = now_ms();
-                room.mark_disconnected(client_id, now);
+                room.mark_disconnected(session.client_id(), now);
                 match room.advance_if_ready(now) {
                     Ok(Some(event)) => Some(event),
                     Ok(None) => Some(EngineEvent::PlayerListChanged),
                     Err(err) => {
                         warn!(
                             room_code,
-                            client_id,
+                            client_id = session.client_id(),
                             code = err.code,
                             message = err.message,
                             "disconnect readiness advance failed"
@@ -737,7 +691,7 @@ async fn disconnect_client(state: &AppState, client_id: &str, connection_id: Uui
         } else {
             Vec::new()
         };
-        send_many(messages);
+        deliver_many(messages);
     }
 }
 
@@ -781,7 +735,7 @@ fn spawn_room_maintenance(state: AppState) {
                     .into_iter()
                     .flat_map(|(room_code, event)| room_messages(&inner, &room_code, event))
                     .collect::<Vec<_>>();
-                send_many(messages);
+                deliver_many(messages);
             }
         }
     });
@@ -795,10 +749,10 @@ fn room_messages(inner: &AppInner, room_code: &str, event: EngineEvent) -> Vec<O
 
     let mut messages = Vec::new();
     for (client_id, conn) in &inner.connections {
-        if conn.room_code.as_deref() != Some(room_code) {
+        if conn.room_code() != Some(room_code) {
             continue;
         }
-        let snapshot = personalize_snapshot(room, &base_snapshot, client_id, &conn.role);
+        let snapshot = personalize_snapshot(room, &base_snapshot, client_id, conn.role());
         let event_message = match event {
             EngineEvent::PhaseChanged => ServerMessage::PhaseChanged {
                 snapshot: snapshot.clone(),
@@ -821,7 +775,7 @@ fn room_messages(inner: &AppInner, room_code: &str, event: EngineEvent) -> Vec<O
             },
         ));
 
-        if snapshot.phase == GamePhase::Drawing && conn.role == Role::Player {
+        if snapshot.phase == GamePhase::Drawing && conn.role() == &Role::Player {
             if let Some(prompt) = room.prompt_for_player(client_id) {
                 messages.push((conn.outbound(), ServerMessage::PromptAssigned { prompt }));
             }
@@ -889,18 +843,18 @@ fn personalize_snapshot(
     snapshot
 }
 
-fn queue_snapshot_for_connection(inner: &AppInner, client_id: &str, snapshot: RoomSnapshot) {
-    if let Some(conn) = inner.connections.get(client_id) {
-        send_many(vec![(
+fn queue_snapshot_for_connection(inner: &AppInner, session: &SessionKey, snapshot: RoomSnapshot) {
+    if let Some(conn) = inner.connection(session) {
+        deliver_many(vec![(
             conn.outbound(),
             ServerMessage::RoomSnapshot { snapshot },
         )]);
     }
 }
 
-fn queue_error_for_connection(inner: &AppInner, client_id: &str, err: EngineError) {
-    if let Some(conn) = inner.connections.get(client_id) {
-        send_many(vec![(
+fn queue_error_for_connection(inner: &AppInner, session: &SessionKey, err: EngineError) {
+    if let Some(conn) = inner.connection(session) {
+        deliver_many(vec![(
             conn.outbound(),
             ServerMessage::Error {
                 code: err.code.to_string(),
@@ -910,17 +864,10 @@ fn queue_error_for_connection(inner: &AppInner, client_id: &str, err: EngineErro
     }
 }
 
-async fn send_error(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    code: &str,
-    message: &str,
-) {
+async fn send_error(state: &AppState, session: &SessionKey, code: &str, message: &str) {
     send_to_client(
         state,
-        client_id,
-        connection_id,
+        session,
         ServerMessage::Error {
             code: code.to_string(),
             message: message.to_string(),
@@ -929,35 +876,23 @@ async fn send_error(
     .await;
 }
 
-async fn send_to_client(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-    message: ServerMessage,
-) {
+async fn send_to_client(state: &AppState, session: &SessionKey, message: ServerMessage) {
     {
         let inner = state.inner.lock().await;
-        if let Some(conn) = inner
-            .connections
-            .get(client_id)
-            .filter(|conn| conn.id == connection_id)
-        {
-            send_many(vec![(conn.outbound(), message)]);
+        if let Some(conn) = inner.connection(session) {
+            deliver_many(vec![(conn.outbound(), message)]);
         }
     }
 }
 
 fn targeted_error(
     inner: &AppInner,
-    client_id: &str,
-    connection_id: Uuid,
+    session: &SessionKey,
     code: &str,
     message: &str,
 ) -> Vec<OutboundMessage> {
     inner
-        .connections
-        .get(client_id)
-        .filter(|conn| conn.id == connection_id)
+        .connection(session)
         .map(|conn| {
             vec![(
                 conn.outbound(),
@@ -970,37 +905,22 @@ fn targeted_error(
         .unwrap_or_default()
 }
 
-fn send_many(messages: Vec<OutboundMessage>) {
-    for (target, message) in messages {
-        if target.tx.try_send(message).is_err() {
-            let _ = target.close_tx.send(true);
-        }
-    }
-}
-
-async fn authorized_controller_room_code(
-    state: &AppState,
-    client_id: &str,
-    connection_id: Uuid,
-) -> Option<String> {
+async fn authorized_controller_room_code(state: &AppState, session: &SessionKey) -> Option<String> {
     let inner = state.inner.lock().await;
-    let conn = inner.connections.get(client_id)?;
-    if conn.id != connection_id {
-        return None;
-    }
-    let room_code = conn.room_code.as_ref()?;
+    let conn = inner.connection(session)?;
+    let room_code = conn.room_code()?;
     let room = inner.rooms.get(room_code)?;
-    match conn.role {
+    match conn.role() {
         Role::Display => {
-            if room.displays.contains(client_id) {
-                Some(room_code.clone())
+            if room.displays.contains(session.client_id()) {
+                Some(room_code.to_string())
             } else {
                 None
             }
         }
         Role::Player => {
-            if room.player_can_control(client_id) {
-                Some(room_code.clone())
+            if room.player_can_control(session.client_id()) {
+                Some(room_code.to_string())
             } else {
                 None
             }
@@ -1124,7 +1044,7 @@ mod tests {
 
     async fn join_player(url: &str, room_code: &str, client_id: &str, name: &str) -> TestSocket {
         let (mut player, _) = connect_async(format!(
-            "{url}?role=player&room={room_code}&clientId={client_id}"
+            "{url}?role=player&room={room_code}&clientId={client_id}&sessionToken={client_id}-session"
         ))
         .await
         .unwrap();
@@ -1150,45 +1070,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn outbound_backpressure_retires_only_the_slow_connection() {
-        let (slow_tx, mut slow_rx) = mpsc::channel(1);
-        let (slow_close_tx, mut slow_close_rx) = watch::channel(false);
-        let slow_target = OutboundTarget {
-            tx: slow_tx,
-            close_tx: slow_close_tx,
-        };
-
-        let (healthy_tx, mut healthy_rx) = mpsc::channel(2);
-        let (healthy_close_tx, healthy_close_rx) = watch::channel(false);
-        let healthy_target = OutboundTarget {
-            tx: healthy_tx,
-            close_tx: healthy_close_tx,
-        };
-
-        send_many(vec![
-            (slow_target.clone(), ServerMessage::Pong { now_ms: 1 }),
-            (slow_target, ServerMessage::Pong { now_ms: 2 }),
-            (healthy_target, ServerMessage::Pong { now_ms: 3 }),
-        ]);
-
-        assert!(matches!(
-            slow_rx.try_recv(),
-            Ok(ServerMessage::Pong { now_ms: 1 })
-        ));
-        slow_close_rx.changed().await.unwrap();
-        assert!(*slow_close_rx.borrow());
-        assert!(matches!(
-            healthy_rx.try_recv(),
-            Ok(ServerMessage::Pong { now_ms: 3 })
-        ));
-        assert!(!*healthy_close_rx.borrow());
-    }
-
-    #[tokio::test]
     async fn retiring_the_current_connection_marks_its_player_disconnected() {
         let room_code = "ABCD".to_string();
         let client_id = "slow-player".to_string();
-        let connection_id = Uuid::new_v4();
         let now = now_ms();
         let mut room = Room::new(
             room_code.clone(),
@@ -1196,27 +1080,28 @@ mod tests {
             "host-token".to_string(),
             now,
         );
-        room.upsert_player(client_id.clone(), "Ada".to_string(), now)
-            .unwrap();
-        let (tx, _rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
-        let (close_tx, _close_rx) = watch::channel(false);
+        let (mut connection, _rx, _close_rx) = Connection::new(
+            client_id.clone(),
+            Role::Player,
+            "slow-player-session".to_string(),
+        );
+        let session = connection.key().clone();
+        room.upsert_player_with_session(
+            client_id.clone(),
+            "slow-player-session".to_string(),
+            "Ada".to_string(),
+            now,
+        )
+        .unwrap();
+        connection.set_room_code(room_code.clone());
         let state = AppState {
             inner: Arc::new(Mutex::new(AppInner {
                 rooms: HashMap::from([(room_code.clone(), room)]),
-                connections: HashMap::from([(
-                    client_id.clone(),
-                    Connection {
-                        id: connection_id,
-                        role: Role::Player,
-                        room_code: Some(room_code.clone()),
-                        tx,
-                        close_tx,
-                    },
-                )]),
+                connections: HashMap::from([(client_id.clone(), connection)]),
             })),
         };
 
-        disconnect_client(&state, &client_id, connection_id).await;
+        disconnect_client(&state, &session).await;
 
         let inner = state.inner.lock().await;
         let snapshot = inner.rooms.get(&room_code).unwrap().snapshot(now_ms());
@@ -1470,13 +1355,15 @@ mod tests {
     #[tokio::test]
     async fn websocket_replacement_closes_the_superseded_connection() {
         let url = spawn_ws_server().await;
-        let (mut original, _) = connect_async(format!("{url}?role=display&clientId=display"))
-            .await
-            .unwrap();
+        let (mut original, _) = connect_async(format!(
+            "{url}?role=display&clientId=display&sessionToken=display-session"
+        ))
+        .await
+        .unwrap();
         let (room_code, host_token, _) = create_test_room(&mut original).await;
 
         let (mut replacement, _) = connect_async(format!(
-            "{url}?role=display&room={room_code}&hostToken={host_token}&clientId=display"
+            "{url}?role=display&room={room_code}&hostToken={host_token}&clientId=display&sessionToken=display-session"
         ))
         .await
         .unwrap();
@@ -1505,6 +1392,50 @@ mod tests {
             .get("nowMs")
             .and_then(Value::as_u64)
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn websocket_rejects_a_second_socket_that_claims_the_host_player_id() {
+        let url = spawn_ws_server().await;
+        let (mut display, _) = connect_async(format!(
+            "{url}?role=display&clientId=display&sessionToken=display-session"
+        ))
+        .await
+        .unwrap();
+        let (room_code, _, _) = create_test_room(&mut display).await;
+        let mut host = join_player(&url, &room_code, "host-phone", "Ada").await;
+
+        let (mut attacker, _) = connect_async(format!(
+            "{url}?role=player&room={room_code}&clientId=host-phone&sessionToken=attacker-session"
+        ))
+        .await
+        .unwrap();
+        let error = read_until_type(&mut attacker, "error").await;
+        assert_eq!(
+            error.get("code").and_then(Value::as_str),
+            Some("session_in_use")
+        );
+
+        host.send(text_message(json!({
+            "type": "updateRoomSettings",
+            "settings": {
+                "rounds": 3,
+                "drawSeconds": 30,
+                "guessSeconds": 20,
+                "voteSeconds": 15,
+                "resultsSeconds": 12,
+                "promptPackId": "safe-party"
+            }
+        })))
+        .await
+        .unwrap();
+        let updated = read_until_settings_rounds(&mut host, 3).await;
+        assert_eq!(
+            updated
+                .pointer("/snapshot/settings/rounds")
+                .and_then(Value::as_u64),
+            Some(3)
+        );
     }
 
     #[tokio::test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -77,6 +77,33 @@ impl AppInner {
             None
         }
     }
+
+    fn disconnect_room_member(&mut self, room_code: &str, client_id: &str) -> Vec<OutboundMessage> {
+        let event = if let Some(room) = self.rooms.get_mut(room_code) {
+            let now = now_ms();
+            room.mark_disconnected(client_id, now);
+            match room.advance_if_ready(now) {
+                Ok(Some(event)) => Some(event),
+                Ok(None) => Some(EngineEvent::PlayerListChanged),
+                Err(err) => {
+                    warn!(
+                        room_code,
+                        client_id,
+                        code = err.code,
+                        message = err.message,
+                        "disconnect readiness advance failed"
+                    );
+                    Some(EngineEvent::PlayerListChanged)
+                }
+            }
+        } else {
+            None
+        };
+
+        event
+            .map(|event| room_messages(self, room_code, event))
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -251,30 +278,54 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
         .session_token
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| Uuid::new_v4().to_string());
+    let requested_room = query
+        .room
+        .as_ref()
+        .map(|room_code| room_code.to_uppercase());
     let (mut ws_sender, mut ws_receiver) = socket.split();
     let (connection, mut rx, mut close_rx) =
         Connection::new(client_id.clone(), query.role.clone(), session_token.clone());
     let session = connection.key().clone();
     let mut receiver_close_rx = close_rx.clone();
 
-    let rejected = {
+    let rejection = {
         let mut inner = state.inner.lock().await;
         if inner
             .connections
             .get(&client_id)
             .is_some_and(|existing| !existing.accepts_session_token(&session_token))
         {
-            true
+            Some((
+                "session_in_use",
+                "This player session is already active on another device.",
+            ))
+        } else if query.role == Role::Player
+            && inner
+                .rooms
+                .values()
+                .any(|room| !room.player_session_matches(&client_id, &session_token))
+        {
+            Some((
+                "invalid_player_session",
+                "This player identity belongs to another device.",
+            ))
         } else {
+            let mut transition_messages = Vec::new();
             if let Some(replaced) = inner.replace_connection(connection) {
+                if replaced.room_code() != requested_room.as_deref() {
+                    if let Some(old_room_code) = replaced.room_code() {
+                        transition_messages.extend(
+                            inner.disconnect_room_member(old_room_code, session.client_id()),
+                        );
+                    }
+                }
                 replaced.retire();
             }
 
-            if let Some(room_code) = &query.room {
-                let room_code = room_code.to_uppercase();
+            if let Some(room_code) = requested_room.as_deref() {
                 if query.role == Role::Display {
                     let now = now_ms();
-                    let snapshot = match inner.rooms.get_mut(&room_code) {
+                    let snapshot = match inner.rooms.get_mut(room_code) {
                         Some(room)
                             if query.host_token.as_deref() == Some(room.host_token.as_str()) =>
                         {
@@ -293,7 +344,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
                     match snapshot {
                         Ok(snapshot) => {
                             if let Some(conn) = inner.connection_mut(&session) {
-                                conn.set_room_code(room_code.clone());
+                                conn.set_room_code(room_code.to_string());
                             }
                             queue_snapshot_for_connection(&inner, &session, snapshot);
                         }
@@ -301,14 +352,15 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
                     }
                 }
             }
-            false
+            deliver_many(transition_messages);
+            None
         }
     };
 
-    if rejected {
+    if let Some((code, message)) = rejection {
         let error = ServerMessage::Error {
-            code: "session_in_use".to_string(),
-            message: "This player session is already active on another device.".to_string(),
+            code: code.to_string(),
+            message: message.to_string(),
         };
         if let Ok(text) = serde_json::to_string(&error) {
             let _ = ws_sender.send(Message::Text(text.into())).await;
@@ -664,33 +716,10 @@ async fn disconnect_client(state: &AppState, session: &SessionKey) {
         let room_code = inner
             .remove_connection(session)
             .and_then(|conn| conn.room_code_owned());
-        let messages = if let Some(room_code) = room_code {
-            let event = if let Some(room) = inner.rooms.get_mut(&room_code) {
-                let now = now_ms();
-                room.mark_disconnected(session.client_id(), now);
-                match room.advance_if_ready(now) {
-                    Ok(Some(event)) => Some(event),
-                    Ok(None) => Some(EngineEvent::PlayerListChanged),
-                    Err(err) => {
-                        warn!(
-                            room_code,
-                            client_id = session.client_id(),
-                            code = err.code,
-                            message = err.message,
-                            "disconnect readiness advance failed"
-                        );
-                        Some(EngineEvent::PlayerListChanged)
-                    }
-                }
-            } else {
-                None
-            };
-            event
-                .map(|event| room_messages(&inner, &room_code, event))
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
+        let messages = room_code
+            .as_deref()
+            .map(|room_code| inner.disconnect_room_member(room_code, session.client_id()))
+            .unwrap_or_default();
         deliver_many(messages);
     }
 }
@@ -1435,6 +1464,100 @@ mod tests {
                 .pointer("/snapshot/settings/rounds")
                 .and_then(Value::as_u64),
             Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_invalid_reclaim_does_not_reserve_a_disconnected_player_id() {
+        let url = spawn_ws_server().await;
+        let (mut display, _) = connect_async(format!(
+            "{url}?role=display&clientId=display&sessionToken=display-session"
+        ))
+        .await
+        .unwrap();
+        let (room_code, _, _) = create_test_room(&mut display).await;
+        let mut host = join_player(&url, &room_code, "host-phone", "Ada").await;
+
+        host.send(text_message(json!({ "type": "leaveRoom" })))
+            .await
+            .unwrap();
+        let _ = read_until_type(&mut display, "playerListChanged").await;
+
+        let (mut attacker, _) = connect_async(format!(
+            "{url}?role=player&room={room_code}&clientId=host-phone&sessionToken=attacker-session"
+        ))
+        .await
+        .unwrap();
+        let error = read_until_type(&mut attacker, "error").await;
+        assert_eq!(
+            error.get("code").and_then(Value::as_str),
+            Some("invalid_player_session")
+        );
+
+        let mut restored = join_player(&url, &room_code, "host-phone", "Ada").await;
+        restored
+            .send(text_message(json!({
+                "type": "updateRoomSettings",
+                "settings": {
+                    "rounds": 3,
+                    "drawSeconds": 30,
+                    "guessSeconds": 20,
+                    "voteSeconds": 15,
+                    "resultsSeconds": 12,
+                    "promptPackId": "safe-party"
+                }
+            })))
+            .await
+            .unwrap();
+        let updated = read_until_settings_rounds(&mut restored, 3).await;
+        assert_eq!(
+            updated
+                .pointer("/snapshot/settings/rounds")
+                .and_then(Value::as_u64),
+            Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_replacement_into_another_room_disconnects_the_old_room_player() {
+        let url = spawn_ws_server().await;
+        let (mut display_a, _) = connect_async(format!(
+            "{url}?role=display&clientId=display-a&sessionToken=display-a-session"
+        ))
+        .await
+        .unwrap();
+        let (room_a, _, _) = create_test_room(&mut display_a).await;
+        let _player_a = join_player(&url, &room_a, "player", "Ada").await;
+        let _ = read_until_type(&mut display_a, "playerListChanged").await;
+
+        let (mut display_b, _) = connect_async(format!(
+            "{url}?role=display&clientId=display-b&sessionToken=display-b-session"
+        ))
+        .await
+        .unwrap();
+        let (room_b, _, _) = create_test_room(&mut display_b).await;
+
+        let (mut player_b, _) = connect_async(format!(
+            "{url}?role=player&room={room_b}&clientId=player&sessionToken=player-session"
+        ))
+        .await
+        .unwrap();
+        player_b
+            .send(text_message(json!({
+                "type": "joinRoom",
+                "roomCode": room_b,
+                "name": "Ada"
+            })))
+            .await
+            .unwrap();
+        let _ = read_until_type(&mut player_b, "roomSnapshot").await;
+
+        let disconnected = read_until_type(&mut display_a, "playerListChanged").await;
+        assert_eq!(
+            disconnected
+                .pointer("/players/0/connected")
+                .and_then(Value::as_bool),
+            Some(false)
         );
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{
-        ws::{Message, WebSocket, WebSocketUpgrade},
+        ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
         Query, Request, State,
     },
     http::{
@@ -39,7 +39,7 @@ use tower_http::{
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use session::{deliver_many, Connection, OutboundMessage, SessionKey};
+use session::{deliver_many, CloseSignal, Connection, OutboundMessage, SessionKey};
 
 #[derive(Clone)]
 struct AppState {
@@ -283,14 +283,14 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
         .as_ref()
         .map(|room_code| room_code.to_uppercase());
     let (mut ws_sender, mut ws_receiver) = socket.split();
-    let (connection, mut rx, mut close_rx) =
+    let (mut connection, mut rx, mut close_rx) =
         Connection::new(client_id.clone(), query.role.clone(), session_token.clone());
     let session = connection.key().clone();
     let mut receiver_close_rx = close_rx.clone();
 
     let rejection = {
         let mut inner = state.inner.lock().await;
-        if inner
+        let admission_error = if inner
             .connections
             .get(&client_id)
             .is_some_and(|existing| !existing.accepts_session_token(&session_token))
@@ -299,61 +299,92 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
                 "session_in_use",
                 "This player session is already active on another device.",
             ))
-        } else if query.role == Role::Player
-            && inner
-                .rooms
-                .values()
-                .any(|room| !room.player_session_matches(&client_id, &session_token))
+        } else if inner
+            .rooms
+            .values()
+            .any(|room| !room.player_session_matches(&client_id, &session_token))
         {
             Some((
                 "invalid_player_session",
                 "This player identity belongs to another device.",
             ))
-        } else {
-            let mut transition_messages = Vec::new();
-            if let Some(replaced) = inner.replace_connection(connection) {
-                if replaced.room_code() != requested_room.as_deref() {
-                    if let Some(old_room_code) = replaced.room_code() {
-                        transition_messages.extend(
-                            inner.disconnect_room_member(old_room_code, session.client_id()),
-                        );
+        } else if let Some(room_code) = requested_room.as_deref() {
+            match query.role {
+                Role::Display => match inner.rooms.get(room_code) {
+                    Some(room) if query.host_token.as_deref() == Some(room.host_token.as_str()) => {
+                        None
                     }
-                }
-                replaced.retire();
+                    Some(_) => Some((
+                        "unauthorized_display",
+                        "This display is not authorized for that room.",
+                    )),
+                    None => Some(("room_not_found", "That room does not exist.")),
+                },
+                Role::Player if inner.rooms.contains_key(room_code) => None,
+                Role::Player => Some(("room_not_found", "That room does not exist.")),
             }
+        } else {
+            None
+        };
 
-            if let Some(room_code) = requested_room.as_deref() {
-                if query.role == Role::Display {
-                    let now = now_ms();
-                    let snapshot = match inner.rooms.get_mut(room_code) {
-                        Some(room)
-                            if query.host_token.as_deref() == Some(room.host_token.as_str()) =>
-                        {
-                            room.add_display(client_id.clone(), now);
-                            Ok(room.snapshot(now))
+        if let Some(error) = admission_error {
+            Some(error)
+        } else {
+            let existing_room_code = inner
+                .connections
+                .get(&client_id)
+                .and_then(Connection::room_code_owned);
+            if existing_room_code.is_some()
+                && existing_room_code.as_deref() != requested_room.as_deref()
+            {
+                Some((
+                    "session_in_use",
+                    "This player session is already active in another room.",
+                ))
+            } else {
+                if let Some(room_code) = existing_room_code.as_deref() {
+                    connection.set_room_code(room_code.to_string());
+                }
+
+                let mut transition_messages = Vec::new();
+                if let Some(replaced) = inner.replace_connection(connection) {
+                    if replaced.room_code() != requested_room.as_deref() {
+                        if let Some(old_room_code) = replaced.room_code() {
+                            transition_messages.extend(
+                                inner.disconnect_room_member(old_room_code, session.client_id()),
+                            );
                         }
-                        Some(_) => Err(EngineError {
-                            code: "unauthorized_display",
-                            message: "This display is not authorized for that room.".to_string(),
-                        }),
-                        None => Err(EngineError {
-                            code: "room_not_found",
-                            message: "That room does not exist.".to_string(),
-                        }),
-                    };
-                    match snapshot {
-                        Ok(snapshot) => {
+                    }
+                    replaced.supersede();
+                }
+
+                if let Some(room_code) = requested_room.as_deref() {
+                    if query.role == Role::Display {
+                        let now = now_ms();
+                        if let Some(room) = inner.rooms.get_mut(room_code) {
+                            room.add_display(client_id.clone(), now);
+                            let snapshot = room.snapshot(now);
                             if let Some(conn) = inner.connection_mut(&session) {
                                 conn.set_room_code(room_code.to_string());
                             }
                             queue_snapshot_for_connection(&inner, &session, snapshot);
                         }
-                        Err(err) => queue_error_for_connection(&inner, &session, err),
+                    } else if inner
+                        .connection(&session)
+                        .is_some_and(|connection| connection.room_code() == Some(room_code))
+                    {
+                        if let Some(room) = inner.rooms.get(room_code) {
+                            queue_snapshot_for_connection(
+                                &inner,
+                                &session,
+                                room.snapshot(now_ms()),
+                            );
+                        }
                     }
                 }
+                deliver_many(transition_messages);
+                None
             }
-            deliver_many(transition_messages);
-            None
         }
     };
 
@@ -373,21 +404,33 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
         loop {
             tokio::select! {
                 changed = close_rx.changed() => {
-                    if changed.is_err() || *close_rx.borrow() {
-                        let _ = ws_sender.send(Message::Close(None)).await;
+                    if changed.is_err() {
+                        break;
+                    }
+                    let signal = *close_rx.borrow();
+                    if let Some(signal) = signal {
+                        let _ = ws_sender.send(close_message(signal)).await;
                         break;
                     }
                 }
                 message = rx.recv() => {
                     let Some(message) = message else {
+                        let signal = *close_rx.borrow();
+                        if let Some(signal) = signal {
+                            let _ = ws_sender.send(close_message(signal)).await;
+                        }
                         break;
                     };
                     match serde_json::to_string(&message) {
                         Ok(text) => {
                             tokio::select! {
                                 changed = close_rx.changed() => {
-                                    if changed.is_err() || *close_rx.borrow() {
-                                        let _ = ws_sender.send(Message::Close(None)).await;
+                                    if changed.is_err() {
+                                        break;
+                                    }
+                                    let signal = *close_rx.borrow();
+                                    if let Some(signal) = signal {
+                                        let _ = ws_sender.send(close_message(signal)).await;
                                         break;
                                     }
                                 }
@@ -408,10 +451,18 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
         }
     });
 
+    let mut sender_task = sender_task;
+    let mut closed_by_server = false;
     loop {
         tokio::select! {
             changed = receiver_close_rx.changed() => {
-                if changed.is_err() || *receiver_close_rx.borrow() {
+                if changed.is_err() {
+                    break;
+                }
+                if receiver_close_rx.borrow().is_some() {
+                    closed_by_server = true;
+                    let _ = (&mut sender_task).await;
+                    let _ = time::timeout(Duration::from_secs(1), ws_receiver.next()).await;
                     break;
                 }
             }
@@ -446,8 +497,20 @@ async fn handle_socket(socket: WebSocket, state: AppState, query: WsQuery) {
         }
     }
 
-    sender_task.abort();
+    if !closed_by_server {
+        sender_task.abort();
+    }
     disconnect_client(&state, &session).await;
+}
+
+fn close_message(signal: CloseSignal) -> Message {
+    match signal {
+        CloseSignal::Superseded => Message::Close(Some(CloseFrame {
+            code: 4001,
+            reason: "superseded".into(),
+        })),
+        CloseSignal::SlowConsumer => Message::Close(None),
+    }
 }
 
 async fn handle_client_message(state: &AppState, session: &SessionKey, message: ClientMessage) {
@@ -686,6 +749,9 @@ where
         if inner.connection(session).is_none() {
             return;
         }
+        let previous_room_code = inner
+            .connection(session)
+            .and_then(Connection::room_code_owned);
         let result = inner
             .rooms
             .get_mut(room_code)
@@ -699,10 +765,18 @@ where
 
         let messages = match result {
             Ok(event) => {
+                let mut messages = previous_room_code
+                    .as_deref()
+                    .filter(|previous_room_code| *previous_room_code != room_code)
+                    .map(|previous_room_code| {
+                        inner.disconnect_room_member(previous_room_code, session.client_id())
+                    })
+                    .unwrap_or_default();
                 if let Some(conn) = inner.connection_mut(session) {
                     conn.set_room_code(room_code.to_string());
                 }
-                room_messages(&inner, room_code, event)
+                messages.extend(room_messages(&inner, room_code, event));
+                messages
             }
             Err(error) => targeted_error(&inner, session, error.code, &error.message),
         };
@@ -877,18 +951,6 @@ fn queue_snapshot_for_connection(inner: &AppInner, session: &SessionKey, snapsho
         deliver_many(vec![(
             conn.outbound(),
             ServerMessage::RoomSnapshot { snapshot },
-        )]);
-    }
-}
-
-fn queue_error_for_connection(inner: &AppInner, session: &SessionKey, err: EngineError) {
-    if let Some(conn) = inner.connection(session) {
-        deliver_many(vec![(
-            conn.outbound(),
-            ServerMessage::Error {
-                code: err.code.to_string(),
-                message: err.message,
-            },
         )]);
     }
 }
@@ -1087,15 +1149,6 @@ mod tests {
             .unwrap();
         let _ = read_until_type(&mut player, "roomSnapshot").await;
         player
-    }
-
-    async fn expect_no_message(ws: &mut TestSocket) {
-        assert!(
-            time::timeout(Duration::from_millis(150), ws.next())
-                .await
-                .is_err(),
-            "unexpected websocket message was received"
-        );
     }
 
     #[tokio::test]
@@ -1342,16 +1395,6 @@ mod tests {
             error.get("code").and_then(Value::as_str),
             Some("unauthorized_display")
         );
-        unauthorized
-            .send(text_message(json!({ "type": "startGame" })))
-            .await
-            .unwrap();
-        let error = read_until_type(&mut unauthorized, "error").await;
-        assert_eq!(
-            error.get("code").and_then(Value::as_str),
-            Some("not_authorized")
-        );
-
         let (mut authorized, _) = connect_async(format!(
             "{url}?role=display&room={room_code}&hostToken={host_token}&clientId=display-2"
         ))
@@ -1378,7 +1421,6 @@ mod tests {
                 .and_then(Value::as_str),
             Some("drawing")
         );
-        expect_no_message(&mut unauthorized).await;
     }
 
     #[tokio::test]
@@ -1407,10 +1449,12 @@ mod tests {
         let closed = time::timeout(Duration::from_secs(1), original.next())
             .await
             .expect("superseded socket did not terminate");
-        assert!(matches!(
-            closed,
-            Some(Ok(WsMessage::Close(_))) | Some(Err(_)) | None
-        ));
+        let frame = match closed {
+            Some(Ok(WsMessage::Close(Some(frame)))) => frame,
+            other => panic!("expected an explicit superseded close frame, got {other:?}"),
+        };
+        assert_eq!(u16::from(frame.code), 4001);
+        assert_eq!(frame.reason, "superseded");
 
         replacement
             .send(text_message(json!({ "type": "heartbeat" })))
@@ -1421,6 +1465,67 @@ mod tests {
             .get("nowMs")
             .and_then(Value::as_u64)
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn websocket_invalid_display_reattach_keeps_the_current_controller() {
+        let url = spawn_ws_server().await;
+        let (mut display, _) = connect_async(format!(
+            "{url}?role=display&clientId=display&sessionToken=display-session"
+        ))
+        .await
+        .unwrap();
+        let (room_code, _, _) = create_test_room(&mut display).await;
+
+        let (mut invalid, _) = connect_async(format!(
+            "{url}?role=display&room={room_code}&hostToken=wrong&clientId=display&sessionToken=display-session"
+        ))
+        .await
+        .unwrap();
+        let error = read_until_type(&mut invalid, "error").await;
+        assert_eq!(
+            error.get("code").and_then(Value::as_str),
+            Some("unauthorized_display")
+        );
+
+        display
+            .send(text_message(json!({ "type": "heartbeat" })))
+            .await
+            .unwrap();
+        assert!(read_until_type(&mut display, "pong")
+            .await
+            .get("nowMs")
+            .and_then(Value::as_u64)
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn websocket_same_room_replacement_keeps_disconnect_cleanup() {
+        let url = spawn_ws_server().await;
+        let (mut display, _) = connect_async(format!(
+            "{url}?role=display&clientId=display&sessionToken=display-session"
+        ))
+        .await
+        .unwrap();
+        let (room_code, _, _) = create_test_room(&mut display).await;
+        let _original = join_player(&url, &room_code, "player", "Ada").await;
+        let _ = read_until_type(&mut display, "playerListChanged").await;
+
+        let (mut replacement, _) = connect_async(format!(
+            "{url}?role=player&room={room_code}&clientId=player&sessionToken=player-session"
+        ))
+        .await
+        .unwrap();
+        let _ = read_until_type(&mut replacement, "roomSnapshot").await;
+        replacement.close(None).await.unwrap();
+
+        let disconnected = read_until_type(&mut display, "playerListChanged").await;
+        assert_eq!(
+            disconnected
+                .pointer("/players/0/connected")
+                .and_then(Value::as_bool),
+            Some(false)
+        );
     }
 
     #[tokio::test]
@@ -1519,7 +1624,46 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn websocket_replacement_into_another_room_disconnects_the_old_room_player() {
+    async fn websocket_display_cannot_squat_a_disconnected_player_id() {
+        let url = spawn_ws_server().await;
+        let (mut display, _) = connect_async(format!(
+            "{url}?role=display&clientId=display&sessionToken=display-session"
+        ))
+        .await
+        .unwrap();
+        let (room_code, _, _) = create_test_room(&mut display).await;
+        let mut host = join_player(&url, &room_code, "host-phone", "Ada").await;
+
+        host.send(text_message(json!({ "type": "leaveRoom" })))
+            .await
+            .unwrap();
+        let _ = read_until_type(&mut display, "playerListChanged").await;
+
+        let (mut attacker, _) = connect_async(format!(
+            "{url}?role=display&room={room_code}&clientId=host-phone&sessionToken=attacker-session"
+        ))
+        .await
+        .unwrap();
+        let error = read_until_type(&mut attacker, "error").await;
+        assert_eq!(
+            error.get("code").and_then(Value::as_str),
+            Some("invalid_player_session")
+        );
+
+        let mut restored = join_player(&url, &room_code, "host-phone", "Ada").await;
+        restored
+            .send(text_message(json!({ "type": "startGame" })))
+            .await
+            .unwrap();
+        let phase = read_until_type(&mut restored, "phaseChanged").await;
+        assert_eq!(
+            phase.pointer("/snapshot/phase").and_then(Value::as_str),
+            Some("drawing")
+        );
+    }
+
+    #[tokio::test]
+    async fn websocket_replacement_cannot_change_rooms_before_joining() {
         let url = spawn_ws_server().await;
         let (mut display_a, _) = connect_async(format!(
             "{url}?role=display&clientId=display-a&sessionToken=display-a-session"
@@ -1527,7 +1671,7 @@ mod tests {
         .await
         .unwrap();
         let (room_a, _, _) = create_test_room(&mut display_a).await;
-        let _player_a = join_player(&url, &room_a, "player", "Ada").await;
+        let mut player_a = join_player(&url, &room_a, "player", "Ada").await;
         let _ = read_until_type(&mut display_a, "playerListChanged").await;
 
         let (mut display_b, _) = connect_async(format!(
@@ -1542,7 +1686,43 @@ mod tests {
         ))
         .await
         .unwrap();
-        player_b
+        let error = read_until_type(&mut player_b, "error").await;
+        assert_eq!(
+            error.get("code").and_then(Value::as_str),
+            Some("session_in_use")
+        );
+
+        player_a
+            .send(text_message(json!({ "type": "heartbeat" })))
+            .await
+            .unwrap();
+        assert!(read_until_type(&mut player_a, "pong")
+            .await
+            .get("nowMs")
+            .and_then(Value::as_u64)
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn websocket_join_into_another_room_disconnects_the_old_room_player() {
+        let url = spawn_ws_server().await;
+        let (mut display_a, _) = connect_async(format!(
+            "{url}?role=display&clientId=display-a&sessionToken=display-a-session"
+        ))
+        .await
+        .unwrap();
+        let (room_a, _, _) = create_test_room(&mut display_a).await;
+        let mut player = join_player(&url, &room_a, "player", "Ada").await;
+        let _ = read_until_type(&mut display_a, "playerListChanged").await;
+
+        let (mut display_b, _) = connect_async(format!(
+            "{url}?role=display&clientId=display-b&sessionToken=display-b-session"
+        ))
+        .await
+        .unwrap();
+        let (room_b, _, _) = create_test_room(&mut display_b).await;
+
+        player
             .send(text_message(json!({
                 "type": "joinRoom",
                 "roomCode": room_b,
@@ -1550,7 +1730,7 @@ mod tests {
             })))
             .await
             .unwrap();
-        let _ = read_until_type(&mut player_b, "roomSnapshot").await;
+        let _ = read_until_type(&mut player, "roomSnapshot").await;
 
         let disconnected = read_until_type(&mut display_a, "playerListChanged").await;
         assert_eq!(

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -4,6 +4,12 @@ use uuid::Uuid;
 
 pub const OUTBOUND_QUEUE_CAPACITY: usize = 16;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CloseSignal {
+    SlowConsumer,
+    Superseded,
+}
+
 /// Identifies one socket generation for a logical browser client.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SessionKey {
@@ -37,9 +43,13 @@ impl Connection {
         client_id: String,
         role: Role,
         session_token: String,
-    ) -> (Self, mpsc::Receiver<ServerMessage>, watch::Receiver<bool>) {
+    ) -> (
+        Self,
+        mpsc::Receiver<ServerMessage>,
+        watch::Receiver<Option<CloseSignal>>,
+    ) {
         let (tx, rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
-        let (close_tx, close_rx) = watch::channel(false);
+        let (close_tx, close_rx) = watch::channel(None);
         let outbound = OutboundTarget { tx, close_tx };
         (
             Self {
@@ -90,26 +100,26 @@ impl Connection {
         self.outbound.clone()
     }
 
-    pub fn retire(&self) {
-        self.outbound.retire();
+    pub fn supersede(&self) {
+        self.outbound.close(CloseSignal::Superseded);
     }
 }
 
 #[derive(Clone)]
 pub struct OutboundTarget {
     tx: mpsc::Sender<ServerMessage>,
-    close_tx: watch::Sender<bool>,
+    close_tx: watch::Sender<Option<CloseSignal>>,
 }
 
 impl OutboundTarget {
     pub fn deliver(&self, message: ServerMessage) {
         if self.tx.try_send(message).is_err() {
-            self.retire();
+            self.close(CloseSignal::SlowConsumer);
         }
     }
 
-    fn retire(&self) {
-        let _ = self.close_tx.send(true);
+    fn close(&self, signal: CloseSignal) {
+        let _ = self.close_tx.send(Some(signal));
     }
 }
 
@@ -128,14 +138,14 @@ mod tests {
     #[tokio::test]
     async fn bounded_delivery_retires_only_the_slow_connection() {
         let (slow_tx, mut slow_rx) = mpsc::channel(1);
-        let (slow_close_tx, mut slow_close_rx) = watch::channel(false);
+        let (slow_close_tx, mut slow_close_rx) = watch::channel(None);
         let slow_target = OutboundTarget {
             tx: slow_tx,
             close_tx: slow_close_tx,
         };
 
         let (healthy_tx, mut healthy_rx) = mpsc::channel(2);
-        let (healthy_close_tx, healthy_close_rx) = watch::channel(false);
+        let (healthy_close_tx, healthy_close_rx) = watch::channel(None);
         let healthy_target = OutboundTarget {
             tx: healthy_tx,
             close_tx: healthy_close_tx,
@@ -152,11 +162,11 @@ mod tests {
             Ok(ServerMessage::Pong { now_ms: 1 })
         ));
         slow_close_rx.changed().await.unwrap();
-        assert!(*slow_close_rx.borrow());
+        assert_eq!(*slow_close_rx.borrow(), Some(CloseSignal::SlowConsumer));
         assert!(matches!(
             healthy_rx.try_recv(),
             Ok(ServerMessage::Pong { now_ms: 3 })
         ));
-        assert!(!*healthy_close_rx.borrow());
+        assert_eq!(*healthy_close_rx.borrow(), None);
     }
 }

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -1,0 +1,162 @@
+use draw_party_server::protocol::{Role, ServerMessage};
+use tokio::sync::{mpsc, watch};
+use uuid::Uuid;
+
+pub const OUTBOUND_QUEUE_CAPACITY: usize = 16;
+
+/// Identifies one socket generation for a logical browser client.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionKey {
+    client_id: String,
+    generation: Uuid,
+}
+
+impl SessionKey {
+    pub fn new(client_id: String) -> Self {
+        Self {
+            client_id,
+            generation: Uuid::new_v4(),
+        }
+    }
+
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+}
+
+pub struct Connection {
+    key: SessionKey,
+    role: Role,
+    room_code: Option<String>,
+    session_token: String,
+    outbound: OutboundTarget,
+}
+
+impl Connection {
+    pub fn new(
+        client_id: String,
+        role: Role,
+        session_token: String,
+    ) -> (Self, mpsc::Receiver<ServerMessage>, watch::Receiver<bool>) {
+        let (tx, rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+        let (close_tx, close_rx) = watch::channel(false);
+        let outbound = OutboundTarget { tx, close_tx };
+        (
+            Self {
+                key: SessionKey::new(client_id),
+                role,
+                room_code: None,
+                session_token,
+                outbound,
+            },
+            rx,
+            close_rx,
+        )
+    }
+
+    pub fn matches(&self, key: &SessionKey) -> bool {
+        self.key == *key
+    }
+
+    pub fn key(&self) -> &SessionKey {
+        &self.key
+    }
+
+    pub fn role(&self) -> &Role {
+        &self.role
+    }
+
+    pub fn room_code(&self) -> Option<&str> {
+        self.room_code.as_deref()
+    }
+
+    pub fn room_code_owned(&self) -> Option<String> {
+        self.room_code.clone()
+    }
+
+    pub fn accepts_session_token(&self, session_token: &str) -> bool {
+        self.session_token == session_token
+    }
+
+    pub fn session_token(&self) -> &str {
+        &self.session_token
+    }
+
+    pub fn set_room_code(&mut self, room_code: String) {
+        self.room_code = Some(room_code);
+    }
+
+    pub fn outbound(&self) -> OutboundTarget {
+        self.outbound.clone()
+    }
+
+    pub fn retire(&self) {
+        self.outbound.retire();
+    }
+}
+
+#[derive(Clone)]
+pub struct OutboundTarget {
+    tx: mpsc::Sender<ServerMessage>,
+    close_tx: watch::Sender<bool>,
+}
+
+impl OutboundTarget {
+    pub fn deliver(&self, message: ServerMessage) {
+        if self.tx.try_send(message).is_err() {
+            self.retire();
+        }
+    }
+
+    fn retire(&self) {
+        let _ = self.close_tx.send(true);
+    }
+}
+
+pub type OutboundMessage = (OutboundTarget, ServerMessage);
+
+pub fn deliver_many(messages: impl IntoIterator<Item = OutboundMessage>) {
+    for (target, message) in messages {
+        target.deliver(message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bounded_delivery_retires_only_the_slow_connection() {
+        let (slow_tx, mut slow_rx) = mpsc::channel(1);
+        let (slow_close_tx, mut slow_close_rx) = watch::channel(false);
+        let slow_target = OutboundTarget {
+            tx: slow_tx,
+            close_tx: slow_close_tx,
+        };
+
+        let (healthy_tx, mut healthy_rx) = mpsc::channel(2);
+        let (healthy_close_tx, healthy_close_rx) = watch::channel(false);
+        let healthy_target = OutboundTarget {
+            tx: healthy_tx,
+            close_tx: healthy_close_tx,
+        };
+
+        deliver_many(vec![
+            (slow_target.clone(), ServerMessage::Pong { now_ms: 1 }),
+            (slow_target, ServerMessage::Pong { now_ms: 2 }),
+            (healthy_target, ServerMessage::Pong { now_ms: 3 }),
+        ]);
+
+        assert!(matches!(
+            slow_rx.try_recv(),
+            Ok(ServerMessage::Pong { now_ms: 1 })
+        ));
+        slow_close_rx.changed().await.unwrap();
+        assert!(*slow_close_rx.borrow());
+        assert!(matches!(
+            healthy_rx.try_recv(),
+            Ok(ServerMessage::Pong { now_ms: 3 })
+        ));
+        assert!(!*healthy_close_rx.borrow());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a documented, phased UI/UX improvement plan and completes the recovery/resilience phase on current `main` without replacing the React TV/phone experience.
- Makes WebSocket delivery bounded and generation-safe: superseded sockets are retired, slow clients cannot grow unbounded queues, and retirement marks the affected player disconnected.
- Makes browser persistence best-effort while retaining the current display host credential in memory, including blocked-storage and stale-persistence coverage.

## Validation

- `cargo fmt --check --manifest-path server/Cargo.toml`
- `cargo clippy --manifest-path server/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path server/Cargo.toml` (67 passed)
- `npm --prefix client run typecheck`
- `npm --prefix client test -- --run` (24 passed)
- `npm --prefix client run build`
- Functional/responsive Playwright matrix, excluding only `TV Bro pixel preview` (22 passed)

The full macOS Playwright invocation additionally exercised the visual suite, but its three TV Bro pixel tests cannot compare because this repository intentionally commits Linux-only snapshot baselines. The functional TV geometry and cross-device coverage pass locally; CI remains the authoritative Linux pixel gate.

## Review

Thermos correctness/security and code-quality lanes both pass after remediation.
