### PR TITLE
fix: recover votes interrupted by reconnect

### DIFF
--- a/client/e2e/helpers.ts
+++ b/client/e2e/helpers.ts
@@ -19,7 +19,8 @@ export async function createPlayers(
   appUrl: (path: string) => string,
   roomCode: string,
   names: string[],
-  viewports: PlayerViewport[] = names.map(() => ({ width: 390, height: 844, isMobile: true }))
+  viewports: PlayerViewport[] = names.map(() => ({ width: 390, height: 844, isMobile: true })),
+  prepareContext?: (context: BrowserContext, index: number) => Promise<void>
 ): Promise<Page[]> {
   const pages: Page[] = [];
   for (const [index, name] of names.entries()) {
@@ -30,6 +31,7 @@ export async function createPlayers(
       viewport: { width: viewport.width, height: viewport.height }
     });
     contexts.push(context);
+    await prepareContext?.(context, index);
 
     const page = await context.newPage();
     await page.goto(appUrl(`/join/${roomCode}`));

--- a/client/e2e/reliability.e2e.ts
+++ b/client/e2e/reliability.e2e.ts
@@ -100,3 +100,86 @@ test('disconnected drawer does not stall drawing phase', async ({ baseURL, brows
     await Promise.all(contexts.map((context) => context.close().catch(() => undefined)));
   }
 });
+
+test('a vote interrupted by reconnect can be submitted again', async ({ baseURL, browser }) => {
+  const contexts: BrowserContext[] = [];
+  const appUrl = makeAppUrl(baseURL);
+
+  try {
+    const tvContext = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+    contexts.push(tvContext);
+    const tv = await tvContext.newPage();
+    await tv.goto(appUrl('/'));
+    await expect(tv.locator('.room-code')).toHaveText(/[A-Z]{4}/);
+    const roomCode = (await tv.locator('.room-code').innerText()).trim();
+
+    const players = await createPlayers(
+      browser,
+      contexts,
+      appUrl,
+      roomCode,
+      ['Ava', 'Bo', 'Cy'],
+      undefined,
+      async (context) => {
+        await context.addInitScript(() => {
+          const NativeWebSocket = window.WebSocket;
+          const sockets: WebSocket[] = [];
+          Object.defineProperty(window, '__drawPartyTestSockets', { value: sockets });
+          window.WebSocket = new Proxy(NativeWebSocket, {
+            construct(target, args) {
+              const socket = Reflect.construct(target, args) as WebSocket;
+              sockets.push(socket);
+              return socket;
+            }
+          });
+        });
+      }
+    );
+
+    await tv.getByRole('button', { name: 'Start Game' }).click();
+    for (const player of players) {
+      await drawStroke(player);
+      await player.getByRole('button', { name: 'Submit Drawing' }).click();
+    }
+
+    await expect(tv.getByText('What did they draw?')).toBeVisible();
+    const guessers = await waitForGuessers(players);
+    for (const [index, guesser] of guessers.entries()) {
+      await guesser.getByPlaceholder('Something that sounds legit…').fill(`reconnect fake ${index}`);
+      await guesser.getByRole('button', { name: 'Submit Fake Title' }).click();
+    }
+    await expect(tv.getByText('Which title is real?')).toBeVisible();
+
+    const interruptedVoter = guessers[0];
+    const interruptedOption = interruptedVoter.locator('button.vote-option:not([disabled])').first();
+    await expect(interruptedOption).toBeVisible();
+    await interruptedVoter.evaluate(() => {
+      const sockets = (
+        window as typeof window & { __drawPartyTestSockets: WebSocket[] }
+      ).__drawPartyTestSockets;
+      const socket = sockets.findLast((candidate) => candidate.readyState === WebSocket.OPEN);
+      if (!socket) {
+        throw new Error('expected an open player WebSocket');
+      }
+      const send = socket.send.bind(socket);
+      socket.send = (data) => {
+        if (typeof data === 'string' && JSON.parse(data).type === 'submitVote') {
+          socket.close();
+          return;
+        }
+        send(data);
+      };
+    });
+    await interruptedOption.click();
+
+    await expect(interruptedVoter.locator('#connection-text')).toHaveText('Connected', { timeout: 5000 });
+    await expect(interruptedVoter.locator('button.vote-option:not([disabled])').first()).toBeVisible();
+    await interruptedVoter.locator('button.vote-option:not([disabled])').first().click();
+
+    const remainingVoter = guessers[1];
+    await remainingVoter.locator('button.vote-option:not([disabled])').first().click();
+    await expect(tv.getByText('The real prompt was')).toBeVisible();
+  } finally {
+    await Promise.all(contexts.map((context) => context.close().catch(() => undefined)));
+  }
+});

--- a/client/src/app/GameProvider.tsx
+++ b/client/src/app/GameProvider.tsx
@@ -57,7 +57,7 @@ interface GameContextValue {
   joinRoom: (roomCode: string, name: string) => void;
   setName: (name: string) => void;
   cancelJoin: () => void;
-  send: (message: ClientMessage) => void;
+  send: (message: ClientMessage) => boolean;
   updateSettings: (settings: RoomSettings) => void;
   toggleSound: () => void;
   haptic: (pattern?: number | number[]) => void;
@@ -149,7 +149,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
   }, []);
 
   const send = useCallback((message: ClientMessage) => {
-    socketRef.current?.send(message);
+    return socketRef.current?.send(message) ?? false;
   }, []);
 
   const applySnapshot = useCallback((next: RoomSnapshot) => {
@@ -299,6 +299,7 @@ export function GameProvider({ children }: { children: ReactNode }): React.JSX.E
           }
         },
         onClose: () => {
+          setSelectedVote(null);
           if (reconnectSuppressedRef.current) {
             return;
           }

--- a/client/src/net.ts
+++ b/client/src/net.ts
@@ -63,9 +63,16 @@ export class GameSocket {
     });
   }
 
-  send(message: ClientMessage): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(message));
+  send(message: ClientMessage): boolean {
+    const socket = this.ws;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+    try {
+      socket.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/client/src/views/player/PlayerPlay.tsx
+++ b/client/src/views/player/PlayerPlay.tsx
@@ -120,8 +120,10 @@ export function PlayerVoting(): React.JSX.Element {
                   className={`${disabled ? 'vote-option disabled' : 'vote-option'}${selected ? ' is-selected' : ''}`}
                   disabled={disabled}
                   onClick={() => {
+                    if (!send({ type: 'submitVote', turnToken, optionId: option.id })) {
+                      return;
+                    }
                     setSelectedVote({ turnToken, optionId: option.id });
-                    send({ type: 'submitVote', turnToken, optionId: option.id });
                     playCue('submit');
                     haptic(10);
                   }}


### PR DESCRIPTION
## Summary

- keep a phone's vote controls retryable when its WebSocket closes while the vote is being sent
- have socket sends report whether they were queued instead of silently locking the UI on a closed connection
- add a deterministic three-player Playwright regression that interrupts a vote, reconnects, retries, and verifies the TV reaches results

## Investigation

The voting UI previously set its optimistic `selectedVote` state before checking whether the WebSocket accepted the message. A connection closing at that instant dropped the vote, but the same-turn reconnect preserved the optimistic selection. The phone returned to `Connected` with every answer disabled while the TV still showed that player as waiting.

The regression test fails against the current production deployment and passes with this change.

## Test plan

- [x] Matched validation to blast radius
- [x] WebSocket / reconnect: `cargo test --manifest-path server/Cargo.toml` — 75 passed
- [x] Client logic: `npm --prefix client test -- --run` — 24 passed
- [x] Client typecheck: `npm --prefix client run typecheck`
- [x] Reconnect regression: `npm run e2e -- --grep "vote interrupted by reconnect"`
- [x] Functional browser suite: `npm run e2e -- --grep-invert "TV Bro pixel preview"` — 23 passed
- [ ] Canonical Linux pixel baselines — delegated to CI because repository baselines are Linux-specific

## Notes

No protocol, scoring, persistence, or visual design changes.
